### PR TITLE
Auto-approve promo-code signups into a trial org (issue #2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ src/data/files.zip
 src/data/knowledge-layer.zip
 .env.test
 .env.production
+.env*

--- a/api/_provision.js
+++ b/api/_provision.js
@@ -57,7 +57,7 @@ async function sendInviteEmail(email, invitationToken) {
  * Returns { ok: true, orgId, invitationId, emailSent, action }
  *      or { ok: false, reason } — caller should fall back to the manual queue.
  */
-export async function provisionTrialAccess({ email, name, company, invitedBy = "system" }) {
+export async function provisionTrialAccess({ email, name, company, invitedBy = "system", promoCode = null }) {
   if (!SB_URL || !SB_KEY) return { ok: false, reason: "not_configured" };
   const cleanEmail = email.trim().toLowerCase();
 
@@ -75,9 +75,13 @@ export async function provisionTrialAccess({ email, name, company, invitedBy = "
     return { ok: true, orgId: pending[0].org_id, invitationId: pending[0].id, emailSent, action: `resent_${action}` };
   }
 
-  // Fresh trial org (plan/run limits come from column defaults, as in _usage.js)
+  // Fresh trial org (plan/run limits come from column defaults, as in
+  // _usage.js). The admitting promo code is stamped on the org — checkout
+  // verifies run-pack eligibility against it (migration 034). Conditional so
+  // non-promo callers (issue #3 admin approval) never touch the column.
   const orgName = (company || name || cleanEmail).trim();
-  const created = await sbFetch("orgs", "POST", { name: orgName });
+  const created = await sbFetch("orgs", "POST",
+    promoCode ? { name: orgName, promo_code: promoCode } : { name: orgName });
   const orgId = Array.isArray(created) ? created[0]?.id : created?.id;
   if (!orgId) {
     console.warn("[provision] Org creation failed:", JSON.stringify(created));

--- a/api/_provision.js
+++ b/api/_provision.js
@@ -1,0 +1,103 @@
+// api/_provision.js — shared trial-org provisioning (underscore file: not routed)
+//
+// Creates a trial org + invitation row and sends the invite email, for flows
+// that approve an access request: promo auto-approve (issue #2) now, the
+// admin Approve queue (issue #3) next. Mirrors the new-user path in
+// api/invite.js — keep the two in sync if the invitation flow changes.
+
+const SB_URL = process.env.VITE_SUPABASE_URL;
+const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
+
+async function sbFetch(path, method = "GET", body = null) {
+  const headers = {
+    apikey: SB_KEY,
+    Authorization: `Bearer ${SB_KEY}`,
+    "Content-Type": "application/json",
+  };
+  if (method === "POST") headers.Prefer = "return=representation";
+  const r = await fetch(`${SB_URL}/rest/v1/${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (method === "DELETE" || r.status === 204) return null;
+  return r.json().catch(() => null);
+}
+
+// Send the Supabase auth invite email carrying the invitation token.
+// Falls back to a password-recovery email if the auth user already exists
+// from a prior partial invite (same handling as api/invite.js).
+async function sendInviteEmail(email, invitationToken) {
+  const authRes = await fetch(`${SB_URL}/auth/v1/invite`, {
+    method: "POST",
+    headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ email, data: { invitation_token: invitationToken } }),
+  });
+  if (authRes.status < 400) return { emailSent: true, action: "invited" };
+
+  const authData = await authRes.json().catch(() => ({}));
+  if (authRes.status === 422 || (authData.msg || "").includes("already been registered")) {
+    try {
+      await fetch(`${SB_URL}/auth/v1/recover`, {
+        method: "POST",
+        headers: { apikey: SB_KEY, "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      return { emailSent: true, action: "recovery_sent" };
+    } catch {}
+  }
+  console.warn("[provision] Auth invite failed:", authRes.status, JSON.stringify(authData));
+  return { emailSent: false, action: "email_failed" };
+}
+
+/**
+ * Provision access for an approved requester: trial org + invitation + email.
+ * The requester becomes admin of their own org so they can invite teammates.
+ *
+ * Returns { ok: true, orgId, invitationId, emailSent, action }
+ *      or { ok: false, reason } — caller should fall back to the manual queue.
+ */
+export async function provisionTrialAccess({ email, name, company, invitedBy = "system" }) {
+  if (!SB_URL || !SB_KEY) return { ok: false, reason: "not_configured" };
+  const cleanEmail = email.trim().toLowerCase();
+
+  // Already a full user → nothing to provision; needs a human look.
+  const existing = await sbFetch(`users?email=eq.${encodeURIComponent(cleanEmail)}&select=id,org_id`);
+  if (Array.isArray(existing) && existing.length > 0) return { ok: false, reason: "existing_user" };
+
+  // Unaccepted, unexpired invitation from an earlier approval → don't create a
+  // second org; re-send the email with the existing token.
+  const pending = await sbFetch(
+    `invitations?email=eq.${encodeURIComponent(cleanEmail)}&accepted_at=is.null&expires_at=gt.${encodeURIComponent(new Date().toISOString())}&select=id,org_id,token&limit=1`
+  );
+  if (Array.isArray(pending) && pending.length > 0) {
+    const { emailSent, action } = await sendInviteEmail(cleanEmail, pending[0].token);
+    return { ok: true, orgId: pending[0].org_id, invitationId: pending[0].id, emailSent, action: `resent_${action}` };
+  }
+
+  // Fresh trial org (plan/run limits come from column defaults, as in _usage.js)
+  const orgName = (company || name || cleanEmail).trim();
+  const created = await sbFetch("orgs", "POST", { name: orgName });
+  const orgId = Array.isArray(created) ? created[0]?.id : created?.id;
+  if (!orgId) {
+    console.warn("[provision] Org creation failed:", JSON.stringify(created));
+    return { ok: false, reason: "org_create_failed" };
+  }
+
+  const invResult = await sbFetch("invitations", "POST", {
+    org_id: orgId,
+    email: cleanEmail,
+    role: "admin",
+    invited_by: invitedBy,
+  });
+  const inv = Array.isArray(invResult) ? invResult[0] : invResult;
+  if (!inv?.token) {
+    console.warn("[provision] Invitation creation failed:", JSON.stringify(invResult));
+    // Don't leave an orphan org with no members and no way in
+    await sbFetch(`orgs?id=eq.${orgId}`, "DELETE").catch(() => {});
+    return { ok: false, reason: "invitation_failed" };
+  }
+
+  const { emailSent, action } = await sendInviteEmail(cleanEmail, inv.token);
+  return { ok: true, orgId, invitationId: inv.id, emailSent, action };
+}

--- a/api/checkout.js
+++ b/api/checkout.js
@@ -2,6 +2,11 @@
 //
 // Creates a Stripe Checkout session for plan upgrades.
 // POST { priceId, planId } with JWT → returns checkout URL.
+// planId "promo_pack" is the one-time $45 / 20-run offer for promo-code
+// signups (issue #2): mode=payment, price resolved server-side from
+// STRIPE_PRICE_PROMO_PACK, eligibility verified against the org's admitting
+// promo code — never trusted from the client, since price IDs ship in the
+// bundle.
 
 import { verifyJwt, decodeJwtPayload, isAllowedOrigin, checkRateLimit } from "./_guard.js";
 
@@ -17,6 +22,10 @@ const PLAN_LIMITS = {
   team:       { run_limit: 250,  max_run_limit: 50 },
   enterprise: { run_limit: 1000, max_run_limit: 200 },
 };
+
+// One-time run pack for promo-code signups — runs added by the webhook via
+// apply_run_pack() (migration 034), keep in sync with stripe-webhook.js.
+const PROMO_PACK_RUNS = 20;
 
 export default async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).end();
@@ -46,10 +55,19 @@ export default async function handler(req, res) {
   if (process.env.STRIPE_PRICE_TEAM) PRICE_TO_PLAN[process.env.STRIPE_PRICE_TEAM] = "team";
   if (process.env.STRIPE_PRICE_ENTERPRISE) PRICE_TO_PLAN[process.env.STRIPE_PRICE_ENTERPRISE] = "enterprise";
 
-  const { priceId } = req.body || {};
-  if (!priceId || typeof priceId !== "string") return res.status(400).json({ error: "priceId required" });
-  const planId = PRICE_TO_PLAN[priceId];
-  if (!planId || !PLAN_LIMITS[planId]) return res.status(400).json({ error: "Invalid price" });
+  const { priceId, planId: requestedPlanId } = req.body || {};
+  const isPack = requestedPlanId === "promo_pack";
+  let planId, sessionPriceId;
+  if (isPack) {
+    sessionPriceId = process.env.STRIPE_PRICE_PROMO_PACK;
+    if (!sessionPriceId) return res.status(500).json({ error: "Promo offer not configured" });
+    planId = "promo_pack";
+  } else {
+    if (!priceId || typeof priceId !== "string") return res.status(400).json({ error: "priceId required" });
+    planId = PRICE_TO_PLAN[priceId];
+    if (!planId || !PLAN_LIMITS[planId]) return res.status(400).json({ error: "Invalid price" });
+    sessionPriceId = priceId;
+  }
 
   // Get user email and org
   let userEmail = "";
@@ -66,12 +84,39 @@ export default async function handler(req, res) {
     return res.status(500).json({ error: "User lookup failed" });
   }
 
+  // Pack eligibility: the org must have been admitted by a promo code whose
+  // row still grants the offer and is active, and must still be on the
+  // trial (or a prior pack's promo) plan.
+  if (isPack) {
+    try {
+      if (!orgId) return res.status(403).json({ error: "This offer isn't available for your account" });
+      const orgRes = await fetch(`${SB_URL}/rest/v1/orgs?id=eq.${orgId}&select=promo_code,plan`, {
+        headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}` },
+      });
+      const org = (await orgRes.json())?.[0];
+      let eligible = false;
+      if (org?.promo_code && (org.plan === "trial" || org.plan === "promo")) {
+        const codeRes = await fetch(
+          `${SB_URL}/rest/v1/promo_codes?code=eq.${encodeURIComponent(org.promo_code)}&grants_run_pack=is.true&active=is.true&select=code`,
+          { headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}` } }
+        );
+        const codes = await codeRes.json();
+        eligible = Array.isArray(codes) && codes.length > 0;
+      }
+      if (!eligible) return res.status(403).json({ error: "This offer isn't available for your account" });
+    } catch (e) {
+      console.error("[checkout] Pack eligibility check failed:", e.message);
+      return res.status(500).json({ error: "Eligibility check failed" });
+    }
+  }
+
   try {
-    // Create Stripe Checkout session
+    // Create Stripe Checkout session — one-time payment for the run pack,
+    // subscription for everything else
     const params = new URLSearchParams();
-    params.append("mode", "subscription");
+    params.append("mode", isPack ? "payment" : "subscription");
     params.append("payment_method_types[0]", "card");
-    params.append("line_items[0][price]", priceId);
+    params.append("line_items[0][price]", sessionPriceId);
     params.append("line_items[0][quantity]", "1");
     params.append("success_url", `${APP_URL}?checkout=success&plan=${planId}`);
     params.append("cancel_url", `${APP_URL}?checkout=cancel`);
@@ -80,9 +125,13 @@ export default async function handler(req, res) {
     params.append("metadata[user_id]", payload.sub);
     params.append("metadata[org_id]", orgId);
     params.append("metadata[plan_id]", planId);
-    params.append("subscription_data[metadata][user_id]", payload.sub);
-    params.append("subscription_data[metadata][org_id]", orgId);
-    params.append("subscription_data[metadata][plan_id]", planId);
+    if (isPack) {
+      params.append("metadata[pack_runs]", String(PROMO_PACK_RUNS));
+    } else {
+      params.append("subscription_data[metadata][user_id]", payload.sub);
+      params.append("subscription_data[metadata][org_id]", orgId);
+      params.append("subscription_data[metadata][plan_id]", planId);
+    }
 
     const stripeRes = await fetch("https://api.stripe.com/v1/checkout/sessions", {
       method: "POST",

--- a/api/knowledge.js
+++ b/api/knowledge.js
@@ -166,7 +166,7 @@ export default async function handler(req, res) {
   // ── Authenticated: knowledge tier based on plan ────────────────────────
   // Trial/free users get core frameworks only (ICP, B2B sales, basic scoring).
   // Paid users get everything including vertical knowledge, compliance, battle cards.
-  const isPaid = userPlan === "paid" || userPlan === "enterprise";
+  const isPaid = userPlan === "paid" || userPlan === "enterprise" || userPlan === "promo";
 
   res.status(200).json({
     _plan: userPlan,

--- a/api/request-access.js
+++ b/api/request-access.js
@@ -1,10 +1,16 @@
 // api/request-access.js
 //
 // Invite-only beta: handles "Request access" form submissions.
-// Inserts the request into access_requests and emails the founder via Resend.
-// Does NOT create any auth account — self-service signup is disabled.
+// No promo code (or an invalid one): inserts the request into access_requests
+// and emails the founder via Resend — a human approves later.
+// Valid promo code: provisions a trial org + invitation and sends the invite
+// email in the same request, no human in the loop (issue #2). Codes live in
+// the promo_codes table (migration 033) so they rotate without a deploy.
+// Does NOT create any auth account directly — signup happens via the emailed
+// invite link.
 
 import { isAllowedOrigin, checkRateLimit } from "./_guard.js";
+import { provisionTrialAccess } from "./_provision.js";
 
 const SB_URL = process.env.VITE_SUPABASE_URL;
 const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
@@ -15,6 +21,73 @@ const FROM_ADDR = "Cambree <noreply@cambree.ai>";
 if (!RESEND_API_KEY) console.warn("[request-access] RESEND_API_KEY not set — founder email disabled");
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const QUEUED_MSG = "Request received. We review every request and send invites personally.";
+const PROMO_MSG = "You're in! Check your email for your invite link.";
+const BAD_CODE_MSG = "That code wasn't recognized, so your request has been queued for review — we'll send your invite personally.";
+
+// Stricter bucket for promo-code attempts so codes can't be enumerated:
+// 5 attempts per 15 minutes per IP. In-memory and per-instance (best effort),
+// same pattern as api/invite.js. The code comparison itself happens inside
+// the redeem_promo_code() SQL function via an index lookup, so response-time
+// differences leak nothing useful; this limit is the real defense.
+const promoAttemptBuckets = new Map();
+function checkPromoAttemptLimit(ip) {
+  const now = Date.now();
+  const bucket = promoAttemptBuckets.get(ip);
+  if (!bucket || (now - bucket.windowStart) > 15 * 60_000) {
+    promoAttemptBuckets.set(ip, { count: 1, windowStart: now });
+    return true;
+  }
+  bucket.count++;
+  return bucket.count <= 5;
+}
+
+async function sbRest(path, method = "GET", body = null, prefer = null) {
+  const headers = { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}`, "Content-Type": "application/json" };
+  if (prefer) headers.Prefer = prefer;
+  return fetch(`${SB_URL}/rest/v1/${path}`, { method, headers, body: body ? JSON.stringify(body) : undefined });
+}
+
+// Atomic validate + consume via SQL (migration 033). False = invalid code.
+async function redeemPromoCode(code) {
+  try {
+    const r = await sbRest("rpc/redeem_promo_code", "POST", { p_code: code });
+    if (!r.ok) { console.warn("[request-access] redeem_promo_code failed:", r.status); return false; }
+    return (await r.json()) === true;
+  } catch (e) {
+    console.warn("[request-access] redeem_promo_code error:", e.message);
+    return false;
+  }
+}
+
+async function notifyFounder({ name, email, company, note, created_at, extra }) {
+  if (!RESEND_API_KEY) return;
+  try {
+    const r = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${RESEND_API_KEY}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        from: FROM_ADDR,
+        to: FOUNDER_EMAIL,
+        reply_to: email,
+        subject: `New Cambree access request — ${company}`,
+        text:
+          `New access request for Cambree private beta:\n\n` +
+          `Name:    ${name}\n` +
+          `Email:   ${email}\n` +
+          `Company: ${company}\n` +
+          (note ? `Note:    ${note}\n` : "") +
+          (extra ? `Flag:    ${extra}\n` : "") +
+          `When:    ${created_at}\n\n` +
+          `Send them an invite from Supabase Auth if approved.`,
+      }),
+    });
+    if (!r.ok) console.warn("[request-access] Resend responded", r.status, await r.text().catch(() => ""));
+  } catch (e) {
+    console.warn("[request-access] Resend call failed:", e.message);
+  }
+}
 
 export default async function handler(req, res) {
   if (req.method !== "POST") return res.status(405).end();
@@ -29,69 +102,77 @@ export default async function handler(req, res) {
            || req.headers["x-real-ip"] || req.socket?.remoteAddress || "unknown";
   if (!checkRateLimit(ip)) return res.status(429).json({ error: "Too many requests" });
 
-  const { name, email, company, note } = req.body || {};
+  const { name, email, company, note, promoCode } = req.body || {};
   if (!name || !email || !company) return res.status(400).json({ error: "Name, email, and company are required" });
   if (!EMAIL_RE.test(email)) return res.status(400).json({ error: "Invalid email format" });
   if (name.length > 200 || email.length > 254 || company.length > 200 || (note && note.length > 2000)) {
     return res.status(400).json({ error: "Input too long" });
   }
+  const code = typeof promoCode === "string" ? promoCode.trim() : "";
+  if (code.length > 64) return res.status(400).json({ error: "Input too long" });
 
   const created_at = new Date().toISOString();
 
-  // Idempotency: if the same email was already submitted within the last 15 minutes, return
-  // success without inserting a duplicate row or re-sending the founder notification email.
+  // Idempotency: if the same email was already submitted within the last 15
+  // minutes, return success without inserting a duplicate row, provisioning a
+  // second org, or re-sending any email.
   const idempotencyWindow = new Date(Date.now() - 15 * 60 * 1000).toISOString();
   try {
-    const dupCheck = await fetch(
-      `${SB_URL}/rest/v1/access_requests?email=eq.${encodeURIComponent(email.trim())}&created_at=gte.${encodeURIComponent(idempotencyWindow)}&select=id&limit=1`,
-      { headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}` } }
+    const dupCheck = await sbRest(
+      `access_requests?email=eq.${encodeURIComponent(email.trim())}&created_at=gte.${encodeURIComponent(idempotencyWindow)}&select=id,status&limit=1`
     );
     if (dupCheck.ok) {
       const rows = await dupCheck.json();
       if (Array.isArray(rows) && rows.length > 0) {
-        return res.json({ ok: true, message: "Request received. We review every request and send invites personally." });
+        const wasApproved = rows[0].status === "approved";
+        return res.json({ ok: true, approved: wasApproved, message: wasApproved ? PROMO_MSG : QUEUED_MSG });
       }
     }
   } catch (e) { console.warn("[request-access] Idempotency check failed:", e.message); }
 
-  // 1. Insert the request row
+  // Promo path: consume a code use, then provision. A consumed use whose
+  // provisioning fails falls back to the manual queue (flagged to the founder).
+  let codeRedeemed = false;
+  if (code) {
+    if (!checkPromoAttemptLimit(ip)) return res.status(429).json({ error: "Too many code attempts — try again later" });
+    codeRedeemed = await redeemPromoCode(code);
+  }
+
+  // Insert the request row (captured id is needed to mark promo approval)
+  let requestId = null;
   try {
-    await fetch(`${SB_URL}/rest/v1/access_requests`, {
-      method: "POST",
-      headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}`, "Content-Type": "application/json", Prefer: "return=minimal" },
-      body: JSON.stringify({ name, email, company, note: note || null, status: "pending", created_at }),
-    });
+    const insRes = await sbRest("access_requests", "POST",
+      { name, email, company, note: note || null, status: "pending", created_at },
+      "return=representation");
+    if (insRes.ok) {
+      const rows = await insRes.json().catch(() => null);
+      requestId = Array.isArray(rows) ? rows[0]?.id : null;
+    }
   } catch (e) {
     console.warn("[request-access] Failed to insert request:", e.message);
   }
 
-  // 2. Email the founder via Resend — fail gracefully (still 200 to the user)
-  if (RESEND_API_KEY) {
-    try {
-      const r = await fetch("https://api.resend.com/emails", {
-        method: "POST",
-        headers: { Authorization: `Bearer ${RESEND_API_KEY}`, "Content-Type": "application/json" },
-        body: JSON.stringify({
-          from: FROM_ADDR,
-          to: FOUNDER_EMAIL,
-          reply_to: email,
-          subject: `New Cambree access request — ${company}`,
-          text:
-            `New access request for Cambree private beta:\n\n` +
-            `Name:    ${name}\n` +
-            `Email:   ${email}\n` +
-            `Company: ${company}\n` +
-            (note ? `Note:    ${note}\n` : "") +
-            `When:    ${created_at}\n\n` +
-            `Send them an invite from Supabase Auth if approved.`,
-        }),
-      });
-      if (!r.ok) console.warn("[request-access] Resend responded", r.status, await r.text().catch(() => ""));
-    } catch (e) {
-      console.warn("[request-access] Resend call failed:", e.message);
+  if (codeRedeemed) {
+    const prov = await provisionTrialAccess({ email, name, company, invitedBy: "system:promo" });
+    if (prov.ok) {
+      if (requestId) {
+        try {
+          await sbRest(`access_requests?id=eq.${requestId}`, "PATCH",
+            { status: "approved", approved_via: "promo", approved_at: new Date().toISOString() },
+            "return=minimal");
+        } catch (e) { console.warn("[request-access] Failed to mark approved:", e.message); }
+      }
+      return res.json({ ok: true, approved: true, message: PROMO_MSG });
     }
+    // Provisioning refused (existing user, etc.) — queue for a human instead.
+    console.warn("[request-access] Promo provisioning fell back to queue:", prov.reason);
+    await notifyFounder({ name, email, company, note, created_at, extra: `Valid promo code, but auto-provision failed (${prov.reason}) — approve manually.` });
+    return res.json({ ok: true, approved: false, message: QUEUED_MSG });
   }
 
+  // Manual queue path (no code, or code not recognized)
+  await notifyFounder({ name, email, company, note, created_at, extra: code ? "Submitted an unrecognized promo code." : null });
+
   // Always succeed for the user once validated — email/DB failures are logged, not surfaced.
-  return res.json({ ok: true, message: "Request received. We review every request and send invites personally." });
+  return res.json({ ok: true, approved: false, message: code ? BAD_CODE_MSG : QUEUED_MSG });
 }

--- a/api/request-access.js
+++ b/api/request-access.js
@@ -142,7 +142,7 @@ export default async function handler(req, res) {
   let requestId = null;
   try {
     const insRes = await sbRest("access_requests", "POST",
-      { name, email, company, note: note || null, status: "pending", created_at },
+      { name, email, company, note: note || null, status: "pending", created_at, promo_code: code || null },
       "return=representation");
     if (insRes.ok) {
       const rows = await insRes.json().catch(() => null);
@@ -153,7 +153,7 @@ export default async function handler(req, res) {
   }
 
   if (codeRedeemed) {
-    const prov = await provisionTrialAccess({ email, name, company, invitedBy: "system:promo" });
+    const prov = await provisionTrialAccess({ email, name, company, invitedBy: "system:promo", promoCode: code });
     if (prov.ok) {
       if (requestId) {
         try {

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -27,6 +27,9 @@ const PLAN_LIMITS = {
   enterprise: { run_limit: 1000, max_run_limit: 200 },
 };
 
+// One-time run pack (plan_id "promo_pack") — same as checkout.js
+const PROMO_PACK_RUNS = 20;
+
 // Stripe sends raw body — need to verify signature
 export const config = { api: { bodyParser: false } };
 
@@ -109,6 +112,39 @@ async function updateOrg(orgId, planId) {
   console.log(`[stripe] Upgraded org ${orgId} to ${planId}: ${limits.run_limit} runs, ${limits.max_run_limit} max`);
 }
 
+// One-time run pack: record the purchase and add the runs in a single
+// transaction (apply_run_pack, migration 034). The session-id PK in
+// promo_pack_purchases makes Stripe retries a no-op even across instances —
+// unlike the subscription path, an increment is not value-idempotent, so the
+// in-memory dedup alone is not enough.
+async function applyRunPack(orgId, session) {
+  if (!orgId) return;
+  try {
+    const r = await fetch(`${SB_URL}/rest/v1/rpc/apply_run_pack`, {
+      method: "POST",
+      headers: {
+        apikey: SB_KEY,
+        Authorization: `Bearer ${SB_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        p_session_id: session.id,
+        p_org_id: orgId,
+        p_runs: PROMO_PACK_RUNS,
+        p_amount_cents: session.amount_total ?? null,
+      }),
+    });
+    const outcome = await r.json().catch(() => null);
+    console.log(`[stripe] Run pack for org ${orgId}: ${outcome}`);
+    if (outcome === "org_not_eligible") {
+      // Payment captured but the org is no longer trial/promo — needs a human.
+      console.warn(`[stripe] Run pack PAID but not applied for org ${orgId} (session ${session.id}) — resolve manually`);
+    }
+  } catch (e) {
+    console.error("[stripe] Run pack apply failed:", e.message);
+  }
+}
+
 async function downgradeOrg(orgId) {
   if (!orgId) return;
 
@@ -176,7 +212,8 @@ export default async function handler(req, res) {
           } catch (e) { console.error("[stripe] Org lookup failed:", e.message); }
         }
         console.log(`[stripe] Checkout completed: user=${userId}, org=${orgId}, plan=${planId}`);
-        await updateOrg(orgId, planId);
+        if (planId === "promo_pack") await applyRunPack(orgId, session);
+        else await updateOrg(orgId, planId);
         break;
       }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4281,9 +4281,9 @@ function PasswordGate({ onAuth }) {
         const r=await fetch("/api/request-access",{
           method:"POST",
           headers:{"Content-Type":"application/json"},
-          body:JSON.stringify({name:(first+" "+last).trim(),email,company,...(promoCode.trim()?{note:"Promo code: "+promoCode.trim()}:{})}),
+          body:JSON.stringify({name:(first+" "+last).trim(),email,company,...(promoCode.trim()?{promoCode:promoCode.trim()}:{})}),
         });
-        if(r.ok){setRequestSent(true);setErr("");}
+        if(r.ok){const d=await r.json().catch(()=>({ok:true}));setRequestSent(d);setErr("");}
         else{const d=await r.json().catch(()=>({}));setErr(d.error||"Could not submit your request — please try again.");reqInFlightRef.current=false;}
         setLoading(false);return;
       }
@@ -4440,10 +4440,14 @@ function PasswordGate({ onAuth }) {
       {mode==="request" ? (
         requestSent ? (
           <div style={{textAlign:"center",padding:"12px 4px"}}>
-            <div style={{fontSize:32,marginBottom:8}}>✓</div>
-            <div style={{fontSize:15,fontWeight:700,color:"var(--green)",marginBottom:8}}>Request received</div>
+            <div style={{fontSize:32,marginBottom:8}}>{requestSent.approved?"🎉":"✓"}</div>
+            <div style={{fontSize:15,fontWeight:700,color:"var(--green)",marginBottom:8}}>
+              {requestSent.approved?"You're in — check your email":"Request received"}
+            </div>
             <div style={{fontSize:13,color:"var(--ink-2)",lineHeight:1.6,marginBottom:16}}>
-              Thanks — we review every request and send invites personally. Watch your inbox.
+              {requestSent.approved
+                ? <>We sent an invite link to <strong style={{color:"var(--ink-0)"}}>{email}</strong>. Click it to set your password and get started.</>
+                : (requestSent.message||"Thanks — we review every request and send invites personally. Watch your inbox.")}
             </div>
             <button type="button" className="btn btn-secondary" style={{width:"100%",justifyContent:"center"}}
               onClick={()=>{setMode("signin");setErr("");setRequestSent(false);}}>Back to Sign In</button>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13036,7 +13036,7 @@ Return ONLY raw JSON:
       // knowledge, compliance, battle cards, etc. Without this, the cached
       // trial-tier layers would persist until the 5-min cache expires.
       setTimeout(fetchKnowledgeLayer, 2500);
-      setChatMessages(prev => [...prev, { role: "assistant", content: `Welcome to the ${plan.charAt(0).toUpperCase()+plan.slice(1)} plan! Your runs have been upgraded. Let's go close some deals.` }]);
+      setChatMessages(prev => [...prev, { role: "assistant", content: plan === "promo_pack" ? "Your 20-run pack is active — the runs are already on your account. Let's go close some deals." : `Welcome to the ${plan.charAt(0).toUpperCase()+plan.slice(1)} plan! Your runs have been upgraded. Let's go close some deals.` }]);
       setChatOpen(true);
     } else if (checkout === "cancel") {
       window.history.replaceState({}, "", window.location.pathname);
@@ -19466,6 +19466,35 @@ Return ONLY raw JSON:
 
             {/* Pricing cards */}
             <div style={{padding:"20px 24px",display:"grid",gridTemplateColumns:"repeat(auto-fit, minmax(145px, 1fr))",gap:10}}>
+              {/* One-time run pack — only for orgs admitted via a promo code, still on trial (or topping up a prior pack). Eligibility is re-verified server-side in /api/checkout. */}
+              {sbUser&&orgCtx?.promo_code&&(orgCtx?.plan==="trial"||orgCtx?.plan==="promo")&&(
+                <div style={{border:"2px solid var(--green)",borderRadius:10,padding:"18px 16px",position:"relative",background:"var(--surface)"}}>
+                  <div style={{position:"absolute",top:-10,left:"50%",transform:"translateX(-50%)",fontSize:10,fontWeight:700,padding:"2px 10px",borderRadius:20,background:"var(--green)",color:"var(--surface)",textTransform:"uppercase",letterSpacing:"0.5px",whiteSpace:"nowrap"}}>Your Offer</div>
+                  <div style={{fontSize:14,fontWeight:700,color:"var(--ink-0)",marginBottom:4}}>Run Pack</div>
+                  <div style={{display:"flex",alignItems:"baseline",gap:2,marginBottom:2}}>
+                    <span style={{fontSize:32,fontWeight:700,color:"var(--ink-0)",fontFamily:"'Crimson Pro',serif"}}>$45</span>
+                    <span style={{fontSize:12,color:"var(--ink-3)"}}>one-time</span>
+                  </div>
+                  <div style={{fontSize:11,color:"var(--tan-0)",fontWeight:600,marginBottom:2}}>20 runs</div>
+                  <div style={{fontSize:11,color:"var(--ink-3)",marginBottom:10}}>Exclusive {orgCtx.promo_code} offer — no subscription</div>
+                  {["Full ICP + brief pipeline","RIVER hypothesis + discovery","Milton coaching","Paid-tier knowledge layers"].map(f=>(
+                    <div key={f} style={{fontSize:11,color:"var(--ink-1)",padding:"2px 0",display:"flex",gap:6}}>
+                      <span style={{color:"var(--green)",flexShrink:0}}>✓</span>{f}
+                    </div>
+                  ))}
+                  <button onClick={async()=>{
+                    try{
+                      const r=await fetch("/api/checkout",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${sbToken}`},body:JSON.stringify({planId:"promo_pack"})});
+                      const d=await r.json();
+                      if(d.url)window.location.href=d.url;
+                      else alert(d.error||"Checkout failed — please try again.");
+                    }catch{alert("Failed to start checkout — check your connection.");}
+                  }}
+                    style={{display:"block",width:"100%",textAlign:"center",padding:"10px",borderRadius:8,background:"var(--green)",color:"var(--surface)",fontSize:12,fontWeight:700,border:"none",cursor:"pointer",marginTop:12,fontFamily:"var(--font-sans)"}}>
+                    Get 20 runs →
+                  </button>
+                </div>
+              )}
               {PRICING_TIERS.map(plan=>(
                 <div key={plan.id} style={{border:plan.popular?"2px solid var(--tan-0)":"1.5px solid var(--line-0)",borderRadius:10,padding:"18px 16px",position:"relative",background:plan.popular?"var(--bg-1)":"var(--surface)"}}>
                   {plan.popular&&<div style={{position:"absolute",top:-10,left:"50%",transform:"translateX(-50%)",fontSize:10,fontWeight:700,padding:"2px 10px",borderRadius:20,background:"var(--tan-0)",color:"var(--surface)",textTransform:"uppercase",letterSpacing:"0.5px",whiteSpace:"nowrap"}}>Most Popular</div>}

--- a/supabase/migrations/033_access_requests_and_promo_codes.sql
+++ b/supabase/migrations/033_access_requests_and_promo_codes.sql
@@ -1,0 +1,86 @@
+-- Migration 033: Reconcile access_requests + add promo codes (issue #2)
+--
+-- 1. access_requests was created out-of-band (Supabase dashboard) and had no
+--    migration. This captures its live production shape (verified 2026-08-03
+--    via PostgREST introspection) so the table is reproducible, and adds the
+--    audit columns for the promo auto-approve path.
+--    Coordination contract with the admin-queue issue (#3): this migration
+--    owns the base shape + approved_via/approved_at; #3 adds
+--    approved_by/dismissed_reason. All ALTERs are IF NOT EXISTS-safe because
+--    staging shares the production database.
+--
+-- 2. promo_codes lets newsletter promo codes be rotated/disabled without a
+--    deploy. Redemption goes through redeem_promo_code() so the
+--    active/max_uses check and the use_count increment are atomic.
+--
+-- Both tables are touched only by server functions using the service_role
+-- key: RLS is enabled with NO policies, so anon/authenticated clients get
+-- nothing (same pattern as the data-science tables, migrations 027/030).
+
+-- ═══════════════════════════════════════════════════════════════
+-- 1. access_requests — reconcile live shape + audit columns
+-- ═══════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS public.access_requests (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name       text NOT NULL,
+  email      text NOT NULL,
+  company    text NOT NULL,
+  note       text,
+  status     text NOT NULL DEFAULT 'pending',  -- 'pending' | 'approved' | 'dismissed' (see issue #3)
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 'promo' (auto-approved via promo code) | 'manual' (admin queue, issue #3)
+ALTER TABLE public.access_requests ADD COLUMN IF NOT EXISTS approved_via text;
+ALTER TABLE public.access_requests ADD COLUMN IF NOT EXISTS approved_at timestamptz;
+
+ALTER TABLE public.access_requests ENABLE ROW LEVEL SECURITY;
+
+-- The 15-minute idempotency window in api/request-access.js queries by
+-- email + created_at on every submission.
+CREATE INDEX IF NOT EXISTS idx_access_requests_email_created
+  ON public.access_requests (email, created_at DESC);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 2. promo_codes
+-- ═══════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS public.promo_codes (
+  code       text PRIMARY KEY,
+  active     boolean NOT NULL DEFAULT true,
+  max_uses   integer,                    -- NULL = unlimited
+  use_count  integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.promo_codes ENABLE ROW LEVEL SECURITY;
+
+-- Seed codes with plain INSERTs from the SQL editor, e.g.:
+--   INSERT INTO public.promo_codes (code, max_uses) VALUES ('NEWSLETTER2026', 100);
+-- Rotate by setting active = false and inserting a new row — no deploy needed.
+
+-- ═══════════════════════════════════════════════════════════════
+-- 3. redeem_promo_code — atomic validate + increment
+-- ═══════════════════════════════════════════════════════════════
+-- Returns true and consumes one use iff the code exists, is active, and has
+-- uses remaining. Single UPDATE so two concurrent redemptions of a code's
+-- last use cannot both succeed.
+
+CREATE OR REPLACE FUNCTION public.redeem_promo_code(p_code text)
+RETURNS boolean AS $$
+DECLARE
+  v_ok boolean := false;
+BEGIN
+  UPDATE public.promo_codes
+  SET use_count = use_count + 1
+  WHERE code = p_code
+    AND active
+    AND (max_uses IS NULL OR use_count < max_uses)
+  RETURNING true INTO v_ok;
+  RETURN COALESCE(v_ok, false);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Service-role only — never redeemable directly from the browser.
+REVOKE EXECUTE ON FUNCTION public.redeem_promo_code(text) FROM PUBLIC, anon, authenticated;

--- a/supabase/migrations/034_promo_run_pack.sql
+++ b/supabase/migrations/034_promo_run_pack.sql
@@ -1,0 +1,113 @@
+-- Migration 034: One-time promo run pack — $45 / 20 runs (issue #2)
+--
+-- Promo codes flagged grants_run_pack unlock a one-time Stripe purchase
+-- (mode=payment, STRIPE_PRICE_PROMO_PACK) that adds runs to the buyer's org.
+-- The org moves to plan='promo', a value the monthly cron never refreshes:
+-- cron-reset-tokens.js only zeroes run_count for plan='trial', and
+-- process_monthly_rollover (redefined below) only cycles plan='paid'. A promo
+-- org's run_count is therefore monotonic and the pack is a true one-time
+-- allotment, not a monthly renewal.
+--
+-- Additive and IF NOT EXISTS-safe, same as 033. Seed the offer after applying:
+--   INSERT INTO promo_codes (code, grants_run_pack) VALUES ('MWFT26', true)
+--   ON CONFLICT (code) DO UPDATE SET grants_run_pack = true;
+
+-- Which promo code admitted this org — stamped at provisioning by
+-- api/_provision.js; api/checkout.js verifies pack eligibility against it
+-- server-side (price IDs ship in the client bundle, so the discounted price
+-- must not be purchasable by guessing).
+ALTER TABLE public.orgs ADD COLUMN IF NOT EXISTS promo_code text;
+
+-- Audit: the code submitted with the access request, recognized or not.
+ALTER TABLE public.access_requests ADD COLUMN IF NOT EXISTS promo_code text;
+
+-- Per-code offer flag — enable/disable the pack offer without a deploy.
+ALTER TABLE public.promo_codes ADD COLUMN IF NOT EXISTS grants_run_pack boolean NOT NULL DEFAULT false;
+
+-- Allow the new plan value.
+ALTER TABLE public.orgs DROP CONSTRAINT IF EXISTS orgs_plan_check;
+ALTER TABLE public.orgs ADD CONSTRAINT orgs_plan_check
+  CHECK (plan IN ('trial', 'paid', 'suspended', 'promo'));
+
+-- Ledger of applied packs. The PK on the Stripe checkout session id is the
+-- idempotency gate for webhook retries (the in-memory dedup in
+-- api/stripe-webhook.js is per-instance best-effort only — an increment is
+-- not value-idempotent like the subscription path's absolute PATCH).
+CREATE TABLE IF NOT EXISTS public.promo_pack_purchases (
+  session_id   text PRIMARY KEY,
+  org_id       uuid NOT NULL REFERENCES public.orgs(id) ON DELETE CASCADE,
+  runs_added   int NOT NULL,
+  amount_cents int,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+-- RLS on, no policies: service-role only, same as promo_codes.
+ALTER TABLE public.promo_pack_purchases ENABLE ROW LEVEL SECURITY;
+
+-- Atomic apply: record the purchase and add the runs in one transaction.
+-- Returns 'duplicate' when the session was already applied (Stripe retry) and
+-- 'org_not_eligible' when the org left trial/promo between checkout and
+-- webhook — payment captured but runs withheld; the webhook logs it for
+-- manual resolution.
+CREATE OR REPLACE FUNCTION public.apply_run_pack(
+  p_session_id text,
+  p_org_id uuid,
+  p_runs int,
+  p_amount_cents int DEFAULT NULL
+)
+RETURNS text AS $$
+BEGIN
+  INSERT INTO public.promo_pack_purchases (session_id, org_id, runs_added, amount_cents)
+  VALUES (p_session_id, p_org_id, p_runs, p_amount_cents)
+  ON CONFLICT (session_id) DO NOTHING;
+  IF NOT FOUND THEN
+    RETURN 'duplicate';
+  END IF;
+
+  UPDATE public.orgs
+     SET run_limit = run_limit + p_runs,
+         plan = 'promo',
+         updated_at = now()
+   WHERE id = p_org_id
+     AND plan IN ('trial', 'promo');
+  IF NOT FOUND THEN
+    RETURN 'org_not_eligible';
+  END IF;
+
+  RETURN 'applied';
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+REVOKE EXECUTE ON FUNCTION public.apply_run_pack(text, uuid, int, int) FROM PUBLIC, anon, authenticated;
+
+-- Monthly rollover now cycles paid orgs only (was: plan != 'trial', which
+-- would also have refreshed promo and suspended orgs' run_count each month).
+CREATE OR REPLACE FUNCTION public.process_monthly_rollover()
+RETURNS jsonb AS $$
+DECLARE
+  v_org record;
+  v_count int := 0;
+BEGIN
+  FOR v_org IN
+    SELECT id, run_count, run_limit, rollover_runs, rollover_cap
+    FROM public.orgs
+    WHERE plan = 'paid'
+    FOR UPDATE
+  LOOP
+    DECLARE
+      v_total_available int := v_org.run_limit + v_org.rollover_runs;
+      v_unused int := GREATEST(0, v_total_available - v_org.run_count);
+      v_new_rollover int := LEAST(v_unused, v_org.rollover_cap);
+    BEGIN
+      UPDATE public.orgs
+      SET run_count = 0,
+          rollover_runs = v_new_rollover,
+          updated_at = now()
+      WHERE id = v_org.id;
+      v_count := v_count + 1;
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object('ok', true, 'orgs_processed', v_count);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
Closes #2.

Newsletter subscribers get a promo code; entering it on the request-access form now provisions a trial org and sends the invite email in the same request — no human in the loop. Everyone else (and any invalid code) still queues for manual approval exactly as before.

## Changes

- **Migration 033**: reconciles `access_requests` into a checked-in migration (live production shape verified via PostgREST introspection) and adds `approved_via`/`approved_at`; new `promo_codes` table (`code`, `active`, `max_uses`, `use_count`) so codes rotate without a deploy; `redeem_promo_code()` validates + increments atomically in one UPDATE, EXECUTE revoked from `anon`/`authenticated`. Per the contract on #2, issue #3 extends this with `approved_by`/`dismissed_reason`.
- **`api/_provision.js`** (underscore = not routed, no function-count impact): shared trial-org provisioning — org + `admin` invitation row + Supabase auth invite email, mirroring `api/invite.js`. Refuses existing users (falls back to the manual queue); re-sends the existing token instead of creating a second org when an unaccepted invitation exists. Reused by the admin Approve queue in #3.
- **`api/request-access.js`**: valid code → insert row, provision, mark `approved`/`approved_via='promo'`, distinct "check your email" response. Invalid/missing code → existing queue + founder-email behavior, with the response noting an unrecognized code was queued. Promo attempts capped at 5 per 15 min per IP (429). The 15-minute idempotency window short-circuits both paths, so duplicates can't create a second org or re-send email. If a code redeems but provisioning refuses, the request queues and the founder email is flagged.
- **`src/App.jsx`**: promo code posts as its own `promoCode` field (previously smuggled through `note`); success card distinguishes the promo "check your email" state from the queued state.

## Deploy prerequisites

1. Apply migration 033 to the shared Supabase DB (additive, `IF NOT EXISTS`-safe) — dashboard SQL editor or `supabase db push`.
2. Seed at least one code: `INSERT INTO promo_codes (code, max_uses) VALUES ('NEWSLETTER2026', 100);`

## Testing

- `npm run build`, `npm run test:lint`, `npm run test:backtest` all pass; ESLint problem count on App.jsx is identical before/after (pre-existing failures untouched).
- Staging preview (shares the production DB — use marked test emails, clean up rows after):
  - Valid code → `access_requests.status = approved`, new trial org, invitation row, invite email received; emailed link → signup → app loads under the trial org.
  - Invalid code → row stays `pending`, no org, founder notified, response notes the code wasn't recognized.
  - Same email re-submitted with a code inside 15 min → no second org/email.
  - 6+ bad codes from one IP → 429.
  - Plain no-code submission unchanged: queued + founder notified.

Note: the invite email is the standard Supabase auth invite for now — #5 owns the Resend welcome email; `_provision.js#sendInviteEmail()` is the single swap point.


## Promo run pack (second commit)

Promo-code users get their 3 free trial runs, then a **one-time $45 purchase for 20 runs** (vs Starter $99/mo). Applies to codes flagged `grants_run_pack` — currently `MWFT26`.

- **Migration 034**: `orgs.promo_code` (stamped at provisioning — checkout verifies eligibility against it server-side), `access_requests.promo_code` audit column, `promo_codes.grants_run_pack`, `promo_pack_purchases` ledger whose session-id PK is the cross-instance idempotency gate for Stripe retries, and atomic `apply_run_pack()` (service-role only). Adds a `'promo'` plan value excluded from **both** monthly cron branches (trial reset and paid rollover — the rollover RPC now targets `plan='paid'` instead of `plan != 'trial'`), so the pack is a true one-time allotment, never a monthly renewal.
- **`api/checkout.js`**: `planId: "promo_pack"` → `mode=payment` session; price resolved server-side from `STRIPE_PRICE_PROMO_PACK` (never sent by the client); 403 unless the org's admitting code still grants the pack, is active, and the org is on `trial`/`promo`.
- **`api/stripe-webhook.js`**: `promo_pack` sessions call `apply_run_pack` (adds 20 to `run_limit`, sets `plan='promo'`) instead of the subscription plan update.
- **`api/knowledge.js`**: `'promo'` orgs get paid-tier knowledge layers.
- **`src/App.jsx`**: "Run Pack — $45 one-time / 20 runs" card in the upgrade modal, shown only to eligible orgs; distinct checkout-success message.

Additional deploy prerequisites:

3. Create a **one-time $45 Price** in Stripe (live + test mode) and set `STRIPE_PRICE_PROMO_PACK` in Vercel (Preview + Production).
4. Apply migration 034 and seed the offer: `INSERT INTO promo_codes (code, grants_run_pack) VALUES ('MWFT26', true) ON CONFLICT (code) DO UPDATE SET grants_run_pack = true;` (done on staging already).


## Run-pack E2E results (staging, 2026-08-05)

Tested on the branch preview against the staging Supabase DB with a **live-mode** Stripe charge (refunded after):

- **Eligibility + card**: org stamped `promo_code='MWFT26'` → Run Pack card appears in the upgrade modal; `POST /api/checkout {planId:"promo_pack"}` returned a `mode=payment` session and Stripe checkout completed for $45.00 (`pi_3U1CV11ukA5Jsm7o1Fx1GIS7`).
- **Run grant**: verified via `apply_run_pack()` — org moved `trial` → `promo`, `run_limit` 3 → 23, ledger row written. Double-apply smoke test confirmed idempotency (second call → `'duplicate'`, no extra runs).
- **Webhook leg**: could not fire automatically — the only Stripe endpoint pointed at production, so the event never reached the preview; the pack was applied manually via the same RPC the webhook calls. Two infra fixes made as a result:
  1. **New staging webhook endpoint** → `https://cambrian-playbook-git-staging-jgalanoiis-projects.vercel.app/api/stripe-webhook` (checkout.session.completed + subscription updated/deleted), with its signing secret set as a `staging`-branch-scoped `STRIPE_WEBHOOK_SECRET` in Vercel Preview. The pack's automatic webhook path gets its true E2E once this PR merges to `staging` (current staging code predates `promo_pack` and no-ops it; the ledger also makes replays safe).
  2. **Production webhook was found broken**: the endpoint still pointed at `www.cambriancatalyst.ai`, which 307-redirects to `www.cambree.ai` since the domain move — Stripe doesn't follow redirects, so all prod deliveries were failing. Endpoint URL updated to `https://www.cambree.ai/api/stripe-webhook`; awaiting the next retry to confirm 200s.
- `STRIPE_PRICE_PROMO_PACK` is set in Vercel (Preview + Production) to the one-off $45 live price `price_1U1CK71ukA5Jsm7oLzEbTgH4`. Migration 034 applied to staging and `MWFT26` seeded with `grants_run_pack=true`.
