### PR TITLE
doc: add AWS Agent Toolkit guidance to CLAUDE.md (issue #12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,3 +153,30 @@ Read on demand — don't preload. **Durable** = still-accurate reference. **Hist
 - Scoring weights: 45/30/25 deterministic (Option C); the 40/30/30 LLM scheme in AGENT_CONTEXT/overview is the old system.
 - Model IDs: trust `src/config/constants.js` + `api/_guard.js` (Sonnet is `claude-sonnet-4-6` as of July 2026); docs citing `claude-sonnet-4-5-20250929` predate the update.
 - Pricing: overview + status-2026-05-04 are authoritative; cost-model.md and wireframe.md figures are earlier drafts.
+
+# AWS Guidance
+
+- Prefer the AWS MCP Server for AWS interactions — it provides sandboxed
+  execution, observability, and audit logging. If unavailable, use the
+  AWS CLI directly.
+- Before starting a task, check whether a relevant AWS skill is available.
+  Load the skill with `retrieve_skill` and prefer its guidance over
+  general knowledge.
+- When uncertain about specific AWS details (API parameters, permissions,
+  limits, error codes), verify against documentation rather than guessing.
+  State uncertainty explicitly if you cannot confirm.
+- When creating infrastructure, prefer infrastructure-as-code (AWS CDK or
+  CloudFormation) over direct CLI commands.
+- When working with infrastructure, follow AWS Well-Architected Framework
+  principles.
+- Do not use em dashes in AWS resource names or descriptions. Use
+  hyphens instead.
+
+## Secret Safety
+
+- MUST load the `aws-secrets-manager` skill first for any secret,
+  credential, API key, token, or password task. MUST NOT call
+  `secretsmanager get-secret-value` or `batch-get-secret-value`, and MUST
+  NOT hit the Secrets Manager Agent daemon directly. MUST use
+  `{{resolve:secretsmanager:secret-id:SecretString:json-key}}` with
+  `asm-exec` so the secret resolves at runtime without entering context.


### PR DESCRIPTION
Closes #12.

Appends the AWS experience rules from [aws/agent-toolkit-for-aws](https://github.com/aws/agent-toolkit-for-aws/blob/main/rules/aws-agent-rules.md) to CLAUDE.md, per the toolkit's setup instructions: prefer the AWS MCP server, load AWS skills before tasks, IaC over ad-hoc CLI commands, and the Secrets Manager safety rules. Doc-only change — no code paths touched.