### PR TITLE
Run metering: meter on user intent, not on a research branch (#17)

### DIFF
--- a/api/meter-run.js
+++ b/api/meter-run.js
@@ -1,0 +1,164 @@
+// api/meter-run.js
+//
+// Meters ONE run at a user-intent boundary.
+//
+// WHY THIS EXISTS
+// Metering used to ride on the `x-billable-run` header attached to the P2
+// executives web-search fallback inside generateBrief(). That call is
+// conditional — it only fires when Phase 0 fails to resolve page-verified
+// executives — and every other candidate call (P1, P2) is cache-gated. The
+// result: two identical user clicks could bill differently, and
+// buildSellerICP ("Analyze my company") never metered at all because
+// streamAIWithSearch had no way to send headers.
+//
+// Production evidence at the time of writing (2026-08-06):
+//   sum(orgs.run_count) = 3   vs   356 briefs in account_outputs
+//   2 of 36 orgs had any run counted
+//   294 unmetered Opus calls (7.88M in / 0.49M out tokens)
+//
+// THE MODEL THIS ENFORCES
+//   Quick Brief   → user clicks "Go"                  → 1 run
+//   Full Session  → user clicks "Analyze my company"  → 1 run
+//   Nothing else meters. Steps 2-9 are included in the Full Session's run.
+//
+// Deliberately dumb: no model call, no research, no caching. It authenticates,
+// checks the org's allowance, increments, and answers. That is the whole job —
+// which is exactly why it is reliable.
+
+import { isAllowedOrigin, checkRateLimit } from "./_guard.js";
+import { extractUserId, checkOrgUsage, incrementUsage, incrementMaxUsage } from "./_usage.js";
+
+// Recognised metering events. Anything else is rejected so a typo on the
+// client can never silently mean "don't bill".
+const KINDS = {
+  quick_brief:  { isMax: false, label: "Quick Brief" },
+  full_session: { isMax: false, label: "Full Sales Session" },
+};
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") return res.status(405).end();
+
+  const origin = req.headers.origin || req.headers.referer || "";
+  if (!isAllowedOrigin(origin)) {
+    return res.status(403).json({ error: { type: "origin_not_allowed" } });
+  }
+
+  // Cheap abuse guard. Signature matches the rest of api/ — checkRateLimit(ip)
+  // returns false when the caller is over the shared 200/min per-IP window.
+  const xff = req.headers["x-forwarded-for"];
+  const ip = req.headers["x-vercel-forwarded-for"]?.split(",")[0]?.trim()
+           || (xff ? xff.split(",").pop().trim() : "")
+           || req.headers["x-real-ip"] || req.socket?.remoteAddress || "unknown";
+  if (!checkRateLimit(ip)) {
+    return res.status(429).json({ error: { type: "rate_limited" } });
+  }
+
+  const kindKey = (req.body && req.body.kind) || "";
+  const kind = KINDS[kindKey];
+  if (!kind) {
+    return res.status(400).json({
+      error: { type: "unknown_kind", message: `kind must be one of: ${Object.keys(KINDS).join(", ")}` },
+    });
+  }
+
+  // Unauthenticated callers cannot consume a run. Guests are handled by the
+  // caller's own guest path (see api/claude.js `req._isGuest`); if guest
+  // metering policy changes, change it here in one place.
+  const userId = extractUserId(req);
+  if (!userId) {
+    return res.status(401).json({ error: { type: "unauthenticated" } });
+  }
+
+  // checkOrgUsage auto-provisions a trial org for users who don't have one,
+  // and accounts for rollover_runs in total_available. Do not reimplement
+  // that math here — it lives in _usage.js and must stay single-sourced.
+  let usage;
+  try {
+    usage = await checkOrgUsage(userId, { isMax: kind.isMax });
+  } catch (e) {
+    // FAIL CLOSED. A metering outage must never hand out free runs.
+    console.error("[meter-run] checkOrgUsage threw:", e && e.message);
+    return res.status(503).json({
+      error: { type: "meter_unavailable", message: "Could not verify your run allowance. Please try again." },
+    });
+  }
+
+  if (!usage.allowed) {
+    const errType =
+      usage.reason === "max_not_available"   ? "max_not_available" :
+      usage.reason === "max_limit_exceeded"  ? "max_limit_exceeded" :
+                                               "usage_limit_exceeded";
+    // Same 402 shape api/claude.js returns, so the existing
+    // "usage-limit-exceeded" client listener and upgrade modal work unchanged.
+    return res.status(402).json({
+      error: { type: errType, message: usage.message || "You've used all your runs." },
+      run_count: usage.run_count,
+      run_limit: usage.run_limit,
+      max_run_count: usage.max_run_count,
+      max_run_limit: usage.max_run_limit,
+      rollover_runs: usage.rollover_runs,
+    });
+  }
+
+  // Increment BEFORE the client starts work. The old post-2xx ordering was
+  // correct when the meter rode on a model call that might fail; here the
+  // user action is the billable event, and under-billing is the failure mode
+  // we are fixing. If generation later fails, "Retry Brief (free)" covers it.
+  try {
+    if (kind.isMax) await incrementMaxUsage(usage.org_id);
+    else            await incrementUsage(usage.org_id);
+  } catch (e) {
+    console.error("[meter-run] increment failed:", e && e.message);
+    return res.status(503).json({
+      error: { type: "meter_unavailable", message: "Could not record your run. Please try again." },
+    });
+  }
+
+  const used = (usage.run_count || 0) + 1;
+  const total = usage.total_available != null ? usage.total_available : usage.run_limit;
+
+  console.log(`[meter-run] ${kind.label} metered · org=${usage.org_id} · ${used}/${total}`);
+
+  return res.status(200).json({
+    ok: true,
+    kind: kindKey,
+    run_count: used,
+    run_limit: usage.run_limit,
+    rollover_runs: usage.rollover_runs || 0,
+    total_available: total,
+    remaining: Math.max(0, (total || 0) - used),
+  });
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   CLIENT COUNTERPART — for src/App.jsx, place adjacent to claudeFetch (~1130).
+   Reproduced here so the whole contract is reviewable in one file; it is
+   added to App.jsx in Commit 2, not imported from here.
+
+   async function meterRun(kind) {
+     try {
+       const r = await fetch("/api/meter-run", {
+         method: "POST",
+         headers: { ...authHeaders(), "Content-Type": "application/json" },
+         body: JSON.stringify({ kind }),
+       });
+       if (r.status === 402) {
+         const d = await r.json().catch(() => ({}));
+         // Same event api/claude.js 402s trigger — opens the upgrade modal.
+         window.dispatchEvent(new CustomEvent("usage-limit-exceeded", { detail: d }));
+         return false;
+       }
+       if (!r.ok) {
+         console.warn("[meterRun] non-OK:", r.status);
+         return false;               // fail closed
+       }
+       const d = await r.json();
+       // Keep the header run counter honest without a refetch.
+       setOrgCtx(prev => prev ? { ...prev, run_count: d.run_count } : prev);
+       return true;
+     } catch (e) {
+       console.warn("[meterRun] network error:", e && e.message);
+       return false;                 // fail closed
+     }
+   }
+   ───────────────────────────────────────────────────────────────────────── */

--- a/api/meter-run.js
+++ b/api/meter-run.js
@@ -25,8 +25,10 @@
 // checks the org's allowance, increments, and answers. That is the whole job —
 // which is exactly why it is reliable.
 
-import { isAllowedOrigin, checkRateLimit } from "./_guard.js";
-import { extractUserId, checkOrgUsage, incrementUsage, incrementMaxUsage } from "./_usage.js";
+import { isAllowedOrigin, checkRateLimit, verifyJwt, decodeJwtPayload } from "./_guard.js";
+import { checkOrgUsage, incrementUsage, incrementMaxUsage } from "./_usage.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // Recognised metering events. Anything else is rejected so a typo on the
 // client can never silently mean "don't bill".
@@ -64,8 +66,17 @@ export default async function handler(req, res) {
   // Unauthenticated callers cannot consume a run. Guests are handled by the
   // caller's own guest path (see api/claude.js `req._isGuest`); if guest
   // metering policy changes, change it here in one place.
-  const userId = extractUserId(req);
-  if (!userId) {
+  //
+  // verifyJwt checks the signature, expiry and issuer — extractUserId alone
+  // only base64-decodes the payload, so a forged `sub` would otherwise let an
+  // unauthenticated caller charge a run to someone else's org. Same pattern as
+  // api/checkout.js: verify, then UUID-validate the sub before it reaches a
+  // service_role query.
+  if (!await verifyJwt(req) || req._isGuest) {
+    return res.status(401).json({ error: { type: "unauthenticated" } });
+  }
+  const userId = decodeJwtPayload((req.headers.authorization || "").slice(7))?.sub;
+  if (!userId || !UUID_RE.test(userId)) {
     return res.status(401).json({ error: { type: "unauthenticated" } });
   }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1310,7 +1310,7 @@ async function streamAI(prompt, onChunk, maxTok=2000, { model = null, signal = n
 //   - Track content block types — only feed TEXT blocks to onChunk
 //   - Use extractJsonWithKey for final parse (handles preamble text)
 // anchorKey: the expected top-level JSON key to find (e.g. "elevatorPitch")
-async function streamAIWithSearch(prompt, onChunk, maxTok=2000, { maxSearches=1, anchorKey=null, onStatus=null, model=null, signal=null, returnRawOnFailure=false, system=null } = {}) {
+async function streamAIWithSearch(prompt, onChunk, maxTok=2000, { maxSearches=1, anchorKey=null, onStatus=null, model=null, signal=null, returnRawOnFailure=false, system=null, extraHeaders={} } = {}) {
   const sleep = ms => new Promise(r => setTimeout(r, ms));
   let response = null;
   for (let attempt = 0; attempt < 3; attempt++) {
@@ -1319,7 +1319,7 @@ async function streamAIWithSearch(prompt, onChunk, maxTok=2000, { maxSearches=1,
       response = await fetch('/api/claude-stream', {
         method: 'POST',
         signal: signal || undefined,
-        headers: { ...authHeaders(), ..._trackingCtx },
+        headers: { ...authHeaders(), ..._trackingCtx, ...extraHeaders },
         body: JSON.stringify({
           model: model || activeModel(),
           max_tokens: maxTok,
@@ -7904,11 +7904,9 @@ Return ONLY raw JSON:
       return;
     }
 
-    // Check usage limit before starting a billable ICP build
-    if (orgCtx && orgCtx.run_count >= orgCtx.run_limit) {
-      setUpgradeOpen(true);
-      return;
-    }
+    // Meter one run for the Full Sales Session at the user-intent boundary.
+    // The gate this replaced checked a counter that was never incremented.
+    if (!(await meterRun("full_session"))) return;
 
     setIcpLoading(true);
     setIcpStatus("Researching your company...");

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7854,6 +7854,26 @@ Return ONLY raw JSON:
     }
   };
 
+  // A Full Sales Session costs ONE run, charged at whichever user-intent boundary
+  // the seller reaches first — "Analyze my company" (scan) or a direct ICP build.
+  // Keyed by normalized seller URL so the scan → confirm → build sequence that
+  // follows a single click is not billed two or three times. Per component mount:
+  // a reload plus a fresh click is a new session and bills again.
+  const fullSessionMeteredRef = useRef(null);
+  const meterFullSession = async (rawUrl) => {
+    const url = _normalizeSellerUrl(rawUrl || "");
+    if (url && fullSessionMeteredRef.current === url) return true; // already paid for this session
+    if (!(await meterRun("full_session"))) return false;
+    fullSessionMeteredRef.current = url;
+    return true;
+  };
+  // Name-only input is metered on what the seller typed ("acme"), then
+  // disambiguation resolves it to a real domain ("acme.io"). Move the paid
+  // marker onto the resolved domain so the scan that follows is not billed again.
+  const _carryFullSessionMeter = (resolvedUrl) => {
+    if (fullSessionMeteredRef.current) fullSessionMeteredRef.current = _normalizeSellerUrl(resolvedUrl || "");
+  };
+
   const buildSellerICP = async(rawUrl, {forceRefresh=false, cacheOnly=false}={}) => {
     // Catch both "research-only" and "research-only.com" before any processing
     if (/^research-only(\.com)?$/i.test((rawUrl || "").trim())) return;
@@ -7906,7 +7926,8 @@ Return ONLY raw JSON:
 
     // Meter one run for the Full Sales Session at the user-intent boundary.
     // The gate this replaced checked a counter that was never incremented.
-    if (!(await meterRun("full_session"))) return;
+    // No-op when the scan already charged this seller URL this session.
+    if (!(await meterFullSession(url))) return;
 
     setIcpLoading(true);
     setIcpStatus("Researching your company...");
@@ -8627,6 +8648,10 @@ Return ONLY raw JSON:
   // ── SCAN SELLER URL FOR PRODUCT PAGES ────────────────────────────────────
   const scanSellerUrl = async(rawUrl) => {
     if(!rawUrl.trim()) return;
+    // Enter-to-scan and the standalone Scan button reach here without passing
+    // through handleSellerGo. Same one-run-per-session dedupe applies, so the
+    // normal button flow is not billed twice.
+    if(!(await meterFullSession(rawUrl))) return;
     const url = rawUrl.trim().replace(/^https?:\/\//,"").replace(/\/$/,"");
     setUrlScanStatus("scanning");
     setUrlScanConfirmed(false);
@@ -13252,6 +13277,10 @@ Return ONLY raw JSON:
   const handleSellerGo = async()=>{
     const norm = sellerInput.trim().replace(/^https?:\/\//,"").replace(/\/$/,"");
     if(!norm) return;
+    // "Analyze my company" IS the Full Session boundary — it kicks off the seller
+    // scan and its speculative Opus research, neither of which reaches
+    // buildSellerICP. Charge here, before any of that work starts.
+    if(!(await meterFullSession(norm))) return;
     const hasUrl = /\.(com|io|ai|org|net|app|co|dev|so|gov|edu|xyz|us|uk|de|fr|eu)($|\/)/i.test(norm);
     if(hasUrl) {
       // URL with TLD — go directly to scan + build
@@ -13290,23 +13319,28 @@ Return ONLY raw JSON:
           // No matches — fall back to name.com
           const fb = norm + ".com";
           setSellerUrl(fb); setSellerInput(fb);
+          _carryFullSessionMeter(fb);
           scanSellerUrl(fb);
         } else if (matches.length === 1) {
           const domain = (matches[0].domain||"").replace(/^https?:\/\//,"").replace(/\/$/,"");
           setSellerUrl(domain); setSellerInput(domain);
+          _carryFullSessionMeter(domain);
           scanSellerUrl(domain);
         } else {
           setDisambigOptions({ matches, input: norm, onSelect: (match) => {
             const domain = (match.domain||"").replace(/^https?:\/\//,"").replace(/\/$/,"");
             setSellerUrl(domain); setSellerInput(domain);
             setDisambigOptions(null);
+            _carryFullSessionMeter(domain);
             scanSellerUrl(domain);
           }});
         }
       } catch (e) {
         console.warn("[Go] Disambiguation failed:", e.message);
         const fb = norm + ".com";
-        setSellerUrl(fb); setSellerInput(fb); scanSellerUrl(fb);
+        setSellerUrl(fb); setSellerInput(fb);
+        _carryFullSessionMeter(fb);
+        scanSellerUrl(fb);
       } finally {
         setDisambigLoading(false);
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2616,7 +2616,7 @@ function generateBrief(member, sellerUrl, sellerDocs, products, selectedCohort, 
         system: JSON_ONLY_SYSTEM,
         tools:[{type:"web_search_20250305",name:"web_search",max_uses:2}],
         messages:[{role:"user",content:execPrompt}],
-      }, { extraHeaders: { "x-billable-run": "1" } });
+      });
       // Gate A — structured per-item extraction from web_search_tool_result blocks.
       // These come directly from Anthropic's search API — the model cannot fabricate them.
       // Bug 2: keep items SEPARATE (not flat-joined) so proximity + recency checks can
@@ -9632,8 +9632,9 @@ Return ONLY raw JSON:
     // Check usage limit before starting a billable brief generation.
     // forceRebuild (Retry Brief / Full Rebuild) is exempt: the UI promises
     // "Retry Brief (free)", and a retry of a failed brief must never be
-    // swallowed by the upgrade modal. Metering itself is unchanged — only the
-    // P2 web-search fallback sends x-billable-run, increments are post-2xx.
+    // swallowed by the upgrade modal. Metering happens once at the
+    // user-intent boundary (Quick Brief Go / Analyze my company) via
+    // /api/meter-run — no model call carries a billing header.
     if (!forceRebuild && orgCtx && orgCtx.run_count >= orgCtx.run_limit) {
       setUpgradeOpen(true);
       return;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7819,6 +7819,41 @@ Return ONLY raw JSON:
     } catch { /* speculation is best-effort — must never break the scan flow */ }
   };
 
+  // Meter one run at a user-intent boundary via /api/meter-run. Returns true when
+  // the run was recorded and work may proceed. Fails closed: anything other than a
+  // 2xx means no run — a metering outage must never hand out free runs.
+  const meterRun = async (kind) => {
+    const meterFailed = () => {
+      setEditToast("Could not verify your run allowance — please try again.");
+      setTimeout(() => setEditToast(""), 5000);
+      return false;
+    };
+    try {
+      const r = await fetch("/api/meter-run", {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ kind }),
+      });
+      if (r.status === 402) {
+        const d = await r.json().catch(() => ({}));
+        // Same event claudeFetch dispatches on 402 — opens the upgrade modal.
+        window.dispatchEvent(new CustomEvent("usage-limit-exceeded", { detail: d }));
+        return false;
+      }
+      if (!r.ok) {
+        console.warn("[meterRun] non-OK:", r.status);
+        return meterFailed();
+      }
+      const d = await r.json();
+      // Keep the header run counter honest without a refetch.
+      setOrgCtx(prev => prev ? { ...prev, run_count: d.run_count } : prev);
+      return true;
+    } catch (e) {
+      console.warn("[meterRun] network error:", e && e.message);
+      return meterFailed();
+    }
+  };
+
   const buildSellerICP = async(rawUrl, {forceRefresh=false, cacheOnly=false}={}) => {
     // Catch both "research-only" and "research-only.com" before any processing
     if (/^research-only(\.com)?$/i.test((rawUrl || "").trim())) return;
@@ -9501,6 +9536,7 @@ Return ONLY raw JSON:
   const verifyAndLaunch = async (input, overrideSellerUrl) => {
     const co = input.trim();
     if (!co) return;
+    if (!(await meterRun("quick_brief"))) return;
     const domain = extractCompanyUrl(co);
     const displayName = extractCompanyName(co);
 


### PR DESCRIPTION
Closes #17

## What this fixes

The free-tier cap does not work. Production has generated **356 briefs against 3 metered runs** — only 2 of 36 orgs have a single run recorded. The `run_count >= run_limit` gate is correct; it guards a counter that almost never increments.

Root cause is architectural: metering was attached to a **conditional research fallback** rather than to the user action. The only `x-billable-run` header in the app sat on the P2 executives web-search fallback inside `generateBrief()`, which fires only when Phase 0 fails to resolve page-verified executives. Meanwhile `buildSellerICP` ("Analyze my company") could not meter at all — `streamAIWithSearch` had no header parameter — leaving ~294 Opus calls (≈$155) unmetered. Every other candidate call is cache-gated, so **no model call is guaranteed to fire per user action**; that is why the fix is a dedicated meter call rather than a relocated header.

## The model this enforces

- Quick Brief → click **Go** → 1 run
- Full Sales Session → click **Analyze my company** → 1 run
- Nothing else meters. Steps 2–9 are included in the Full Session's run.
- Retry Brief / Full Rebuild remain free (they call `pickAccount(..., true)` directly and never reach the meter).

## Commits

| Commit | Change |
|---|---|
| 1 | Add `api/meter-run.js` — authenticate, check allowance, increment, return 402 when over limit. Dead code on purpose so it reviews and reverts independently. |
| 2 | Add the `meterRun(kind)` client helper and gate `verifyAndLaunch` (Quick Brief). |
| 3 | Replace the dead gate in `buildSellerICP` with `meterRun("full_session")`; add `extraHeaders` to `streamAIWithSearch` (plumbing only, no call site uses it). |
| 4 | Remove `x-billable-run` from the P2 fallback so nothing double-meters. Server-side header support in `api/claude.js` stays intact as the rollback path. |
| 5 | **Security fix** — see below. |

Commits 2 and 4 must not be split across deploys: between them a Quick Brief whose P2 falls through would double-meter.

## Security review — one High finding, fixed in commit 5

A mandatory `/security-review` on this branch (it touches billing) found an **authentication bypass in the new endpoint as originally specified**, confirmed by two independent verification passes.

`api/meter-run.js` derived caller identity from `extractUserId()`, which only base64-decodes the JWT payload — no signature, expiry, issuer, or algorithm check. `api/claude.js` uses the same helper safely because `guard()` has already run `verifyJwt()`; this endpoint imported only `isAllowedOrigin` and `checkRateLimit`, so nothing verified the token. It was the only endpoint in `api/` deriving identity that way.

Exploit: a forged `Authorization: Bearer <{"alg":"none"}>.<{"sub":"<uuid>"}>.x` with a spoofed `Origin` (trivial from curl) would charge a run to another org, disclose that org's `run_count`/`run_limit`/`rollover_runs` in the response body, and — with a `sub` matching no user — reach `provisionTrialOrg` to create arbitrary `orgs` rows via the service_role key, all unauthenticated.

Fix adopts the existing `api/checkout.js` pattern: `verifyJwt()` (signature + expiry + issuer), reject guests, then UUID-validate `sub` before it reaches a PostgREST query. Kept as a separate commit so the deviation from the original spec is explicit and revertible.

### Related pre-existing issue (not fixed here)

Verification also confirmed that the model proxies enforce run limits **only** when the client sends `x-billable-run`, so `/api/meter-run` mints no server-side state that `/api/claude(-stream)` consults. A modified client can still skip metering entirely. This predates this PR — the header was always client-supplied and rode on one conditional path — so it is out of scope here and deserves its own issue.

## Verification

- `npm run build` clean; `npm run test:lint` 0 errors; `npm run test:backtest` 9/9 passed.
- `npx eslint` on both changed files: no new errors in any touched region.
- `grep -rn "x-billable" src/` returns nothing — zero client call sites remain.
- Golden set **not** run: it costs money and this change touches only metering, never generation.

## Staging QA still required before promotion to main

- [ ] Quick Brief → Go → `run_count` increments by exactly 1.
- [ ] Full Session → Analyze my company → +1 exactly; walk steps 2→9 and confirm no further increment.
- [ ] Set `run_limit = run_count` → both entry points show the upgrade modal and generate nothing.
- [ ] Simulate a 500 from `/api/meter-run` → no brief generated (fails closed).
- [ ] Promo-code signup flow (#2): confirm which allowance a promo org actually receives — the work order says 3 runs, the promo pack grants 20. The endpoint reads whatever `checkOrgUsage` reports rather than hardcoding, so both should work, but it is untested against the new flow.

## Rollback

Additive endpoint plus three `App.jsx` edits. Revert the last commit to restore prior behavior; revert all five and delete `api/meter-run.js` for a complete rollback. No migration, no schema change, no backfill.
