### PR TITLE
Admin dash: Approve/Dismiss queue for access requests (#3)

### DIFF
--- a/api/_admin-action.js
+++ b/api/_admin-action.js
@@ -4,6 +4,7 @@
 // POST with admin JWT + action payload.
 
 import { isAllowedOrigin, verifyJwt, decodeJwtPayload, checkRateLimit } from "./_guard.js";
+import { provisionTrialAccess } from "./_provision.js";
 
 const SB_URL = process.env.VITE_SUPABASE_URL;
 const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
@@ -193,6 +194,62 @@ export default async function handler(req, res) {
       console.log("[admin] create_org response:", r.status, JSON.stringify(d));
       if (d?.[0]?.id) return res.json({ ok: true, message: `Created "${orgData.name}"`, orgId: d[0].id });
       return res.status(400).json({ error: d?.message || d?.error || d?.details || `Failed to create org (${r.status})` });
+    }
+
+    if (action === "approve_access_request" || action === "dismiss_access_request") {
+      const { requestId, reason } = req.body || {};
+      if (!requestId) return res.status(400).json({ error: "requestId required" });
+      if (!UUID_RE.test(requestId)) return res.status(400).json({ error: "Invalid requestId format" });
+
+      const isApprove = action === "approve_access_request";
+      const patch = isApprove
+        ? { status: "approved", approved_via: "manual", approved_by: callerEmail, approved_at: new Date().toISOString() }
+        : {
+            status: "dismissed",
+            dismissed_reason: typeof reason === "string" && reason.trim() ? reason.trim().slice(0, 500) : null,
+            // approved_by/approved_at double as the generic "actioned by/at"
+            // audit pair on dismissals (see migration 035).
+            approved_by: callerEmail,
+            approved_at: new Date().toISOString(),
+          };
+
+      // Conditional claim: only a 'pending' row transitions. A double-click or
+      // concurrent tab matches zero rows and no-ops, so exactly one org and
+      // one email can ever result from a single request row.
+      const claimRes = await fetch(`${SB_URL}/rest/v1/access_requests?id=eq.${requestId}&status=eq.pending`, {
+        method: "PATCH",
+        headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}`, "Content-Type": "application/json", Prefer: "return=representation" },
+        body: JSON.stringify(patch),
+      });
+      const claimed = await claimRes.json().catch(() => null);
+      if (!claimRes.ok) return res.status(400).json({ error: claimed?.message || "Failed to update request" });
+      if (!Array.isArray(claimed) || claimed.length === 0) {
+        return res.json({ ok: true, noop: true, message: "Request was already actioned" });
+      }
+      const row = claimed[0];
+
+      if (!isApprove) {
+        console.log(`[admin] Dismissed access request ${requestId} (${row.email})`);
+        return res.json({ ok: true, message: `Dismissed request from ${row.email}` });
+      }
+
+      // Approve: trial org + invitation + welcome email — same shared path as
+      // promo auto-approve. The claim above is the idempotency gate.
+      const prov = await provisionTrialAccess({ email: row.email, name: row.name, company: row.company, invitedBy: callerEmail });
+      if (prov.ok) {
+        console.log(`[admin] Approved access request ${requestId} (${row.email}) — org ${prov.orgId}, ${prov.action}`);
+        return res.json({ ok: true, message: `Approved ${row.email} — invite ${prov.emailSent ? "sent" : "NOT sent (check logs)"}` });
+      }
+
+      // Provisioning refused (existing user, etc.) — release the claim so the
+      // row returns to the queue instead of being stuck 'approved' with no org.
+      await fetch(`${SB_URL}/rest/v1/access_requests?id=eq.${requestId}&status=eq.approved`, {
+        method: "PATCH",
+        headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}`, "Content-Type": "application/json", Prefer: "return=minimal" },
+        body: JSON.stringify({ status: "pending", approved_via: null, approved_by: null, approved_at: null }),
+      }).catch(() => {});
+      console.warn(`[admin] Approve of ${requestId} (${row.email}) failed provisioning: ${prov.reason}`);
+      return res.status(400).json({ error: `Provisioning failed: ${prov.reason}` });
     }
 
     return res.status(400).json({ error: `Unknown action: ${action}` });

--- a/api/admin.js
+++ b/api/admin.js
@@ -84,7 +84,7 @@ export default async function handler(req, res) {
     // Fetch all data in parallel
     // sessionIndex: lightweight query of ALL sessions (no data blob) for accurate per-user counts
     // sessions: paginated with full data blob for session detail view
-    const [users, orgs, sessionIndex, sessions, usageLogs, guestLogs, dbCosts] = await Promise.all([
+    const [users, orgs, sessionIndex, sessions, usageLogs, guestLogs, dbCosts, accessRequestRows] = await Promise.all([
       sbFetch("users?select=id,email,name,role,org_id,created_at,last_login&order=created_at.desc"),
       sbFetch("orgs?select=id,name,seller_url,plan,run_count,run_limit,max_run_count,max_run_limit,created_at&order=created_at.desc"),
       // ALL sessions — lightweight (no data blob) for accurate user activity stats
@@ -95,7 +95,12 @@ export default async function handler(req, res) {
       sbFetch("api_usage_log?user_id=is.null&select=model,input_tokens,output_tokens,web_searches,endpoint,created_at&order=created_at.desc&limit=2000"),
       // Server-side cost aggregation (bypasses row limits)
       fetch(`${SB_URL}/rest/v1/rpc/get_cost_summary`, { method: "POST", headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}`, "Content-Type": "application/json" }, body: "{}" }).then(r => r.json()).catch(() => null),
+      // Pending beta access requests for the Approve/Dismiss queue (issue #3)
+      sbFetch("access_requests?status=eq.pending&select=id,name,email,company,note,promo_code,created_at&order=created_at.desc").catch(() => []),
     ]);
+
+    // PostgREST errors come back as an object, not an array — treat as empty
+    const accessRequests = Array.isArray(accessRequestRows) ? accessRequestRows : [];
 
     // Build user activity map
     const now = Date.now();
@@ -592,6 +597,7 @@ export default async function handler(req, res) {
         unique_seller_urls: allSellerUrls.length,
         total_milton_messages: totalMiltonMessages,
         guest_api_calls: guestActivity.total_calls,
+        pending_access_requests: accessRequests.length,
       },
       pagination: { page, limit, total: totalSessions },
       environment: envStatus,
@@ -602,6 +608,7 @@ export default async function handler(req, res) {
         org_plan: u.org_id && orgMap[u.org_id] ? orgMap[u.org_id].plan : null,
       })),
       orgs: Object.entries(orgMap).map(([id, o]) => ({ id, ...o })),
+      access_requests: accessRequests,
       recent_activity: recentActivity,
       seller_urls: allSellerUrls,
       costs,

--- a/src/components/SuperAdmin.jsx
+++ b/src/components/SuperAdmin.jsx
@@ -51,6 +51,10 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
   const cleanupRef = useRef(null);
   const [expandedSession, setExpandedSession] = useState(null);
 
+  // ── Access-request queue state (issue #3) ──
+  const [requestBusy, setRequestBusy] = useState(null); // request id being actioned
+  const [removedRequests, setRemovedRequests] = useState([]); // optimistic removals, rolled back on error
+
   // ── Sort state for Members table ──
   const [memberSortKey, setMemberSortKey] = useState(null);
   const [memberSortDir, setMemberSortDir] = useState("asc");
@@ -241,6 +245,32 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
     } catch { setPlanSaveMsg("Error applying plan"); }
   };
 
+  // ── Access-request queue (issue #3) ──
+  const pendingRequests = (data.access_requests || []).filter(rq => !removedRequests.includes(rq.id));
+  const actOnRequest = async (rq, action, reason) => {
+    setRequestBusy(rq.id);
+    setRemovedRequests(prev => [...prev, rq.id]); // optimistic removal
+    try {
+      const r = await fetch("/api/admin", {
+        method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+        body: JSON.stringify({ action, requestId: rq.id, email: rq.email, ...(reason ? { reason } : {}) }),
+      });
+      const d = await r.json();
+      if (d.ok) {
+        setPlanSaveMsg(d.message || "Done");
+        setTimeout(() => fetchData(false), 500);
+      } else {
+        setRemovedRequests(prev => prev.filter(id => id !== rq.id)); // rollback
+        setPlanSaveMsg(`Error: ${d.error || "Action failed"}`);
+      }
+    } catch {
+      setRemovedRequests(prev => prev.filter(id => id !== rq.id)); // rollback
+      setPlanSaveMsg("Failed to update request");
+    }
+    setRequestBusy(null);
+    setTimeout(() => setPlanSaveMsg(""), 4000);
+  };
+
   // ── Sidebar nav config ──
   const navGroups = [
     {
@@ -250,6 +280,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
       label: "PEOPLE",
       items: [
         { id: "users", label: "Users", count: s.total_users, sub: "Accounts, roles, activity" },
+        { id: "requests", label: "Access Requests", count: pendingRequests.length, sub: "Approve or dismiss beta requests" },
         { id: "orgs", label: "Organizations", count: s.total_orgs, sub: "Teams, plans, run limits" },
       ],
     },
@@ -531,6 +562,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                     const atLimit = (data.orgs || []).filter(o => o.run_count >= o.run_limit && o.run_limit > 0).length;
                     const personalOrgs = (data.orgs || []).filter(o => !o.seller_url && o.member_count <= 1).length;
                     const items = [];
+                    if (pendingRequests.length > 0) items.push({ text: `${pendingRequests.length} access request${pendingRequests.length > 1 ? "s" : ""} awaiting review`, color: "var(--amber)", click: () => setTab("requests") });
                     const orphanUsers = (data.users || []).filter(u => !u.org_id).length;
                     if (orphanUsers > 0) items.push({ text: `${orphanUsers} users without an organization`, color: "var(--red)", click: () => { setUserStatusFilter("orphan"); setTab("users"); } });
                     if (neverActive > 0) items.push({ text: `${neverActive} users never active`, color: "var(--amber)", click: () => { setUserStatusFilter("never_active"); setTab("users"); } });
@@ -1158,6 +1190,65 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                 </tbody>
               </table>
               {filteredUsers.length === 0 && <div style={{ textAlign: "center", color: "var(--ink-3)", fontSize: 13, padding: 20 }}>No members match the current filters.</div>}
+            </div>
+          )}
+
+          {/* ═══ ACCESS REQUESTS ═══ */}
+          {tab === "requests" && (
+            <div>
+              <div style={{ fontSize: 11, fontWeight: 700, color: "var(--ink-2)", textTransform: "uppercase", letterSpacing: "0.4px", marginBottom: 8 }}>
+                Pending Access Requests ({pendingRequests.length})
+              </div>
+              {pendingRequests.length === 0 ? (
+                <div style={{ textAlign: "center", color: "var(--ink-3)", fontSize: 13, padding: 20 }}>No pending access requests.</div>
+              ) : (
+                <table className="admin-table">
+                  <thead>
+                    <tr>
+                      <th>Name / Email</th>
+                      <th>Company</th>
+                      <th>Note</th>
+                      <th>Requested</th>
+                      <th style={{ width: 170 }}>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pendingRequests.map(rq => {
+                      const busy = requestBusy === rq.id;
+                      return (
+                        <tr key={rq.id}>
+                          <td>
+                            <div style={{ fontWeight: 700, color: "var(--ink-0)", fontSize: 13 }}>{rq.name}</div>
+                            <div style={{ fontSize: 11, color: "var(--ink-3)", marginTop: 1 }}>{rq.email}</div>
+                          </td>
+                          <td style={{ color: "var(--ink-1)", fontSize: 12 }}>{rq.company}</td>
+                          <td style={{ fontSize: 11, color: "var(--ink-2)", maxWidth: 260 }}>
+                            {rq.note || "—"}
+                            {rq.promo_code && <div style={{ fontSize: 9, color: "var(--amber)", fontWeight: 600, marginTop: 2 }}>Code: {rq.promo_code}</div>}
+                          </td>
+                          <td style={{ fontSize: 11, color: "var(--ink-3)", whiteSpace: "nowrap" }} title={rq.created_at}>{timeAgo(rq.created_at)}</td>
+                          <td>
+                            <div style={{ display: "flex", gap: 6 }}>
+                              <button disabled={busy} onClick={() => actOnRequest(rq, "approve_access_request")}
+                                style={{ padding: "5px 12px", borderRadius: 6, border: "none", background: "var(--green)", color: "var(--surface)", fontSize: 11, fontWeight: 700, cursor: busy ? "default" : "pointer", opacity: busy ? 0.6 : 1 }}>
+                                {busy ? "Working..." : "Approve"}
+                              </button>
+                              <button disabled={busy} onClick={() => {
+                                const reason = window.prompt(`Dismiss the request from ${rq.email}? No email will be sent.\n\nOptional reason (OK to confirm, Cancel to abort):`);
+                                if (reason === null) return; // cancelled
+                                actOnRequest(rq, "dismiss_access_request", reason.trim());
+                              }}
+                                style={{ padding: "5px 12px", borderRadius: 6, border: "1.5px solid var(--red)", background: "var(--surface)", color: "var(--red)", fontSize: 11, fontWeight: 700, cursor: busy ? "default" : "pointer", opacity: busy ? 0.6 : 1 }}>
+                                Dismiss
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              )}
             </div>
           )}
 

--- a/supabase/migrations/035_access_requests_admin_queue.sql
+++ b/supabase/migrations/035_access_requests_admin_queue.sql
@@ -1,0 +1,18 @@
+-- Migration 035: access_requests admin-queue audit columns (issue #3)
+--
+-- Completes the coordination contract in migration 033: 033 owns the base
+-- table shape plus approved_via/approved_at (promo auto-approve, issue #2);
+-- this migration adds the two columns owned by the admin Approve/Dismiss
+-- queue. Additive and IF NOT EXISTS-safe, same as 033/034.
+--
+-- approved_by records which admin actioned the row (superuser email, or
+-- 'system:promo'-style markers if automation ever stamps it). It is set on
+-- BOTH approve and dismiss — together with approved_at it doubles as the
+-- generic "actioned by/at" audit pair, so a dismissal's who/when/why is
+-- queryable without a third pair of columns:
+--   approve → status='approved',  approved_via='manual', approved_by, approved_at
+--   dismiss → status='dismissed', dismissed_reason,      approved_by, approved_at
+-- Rows are status-flagged, never deleted, so history remains queryable.
+
+ALTER TABLE public.access_requests ADD COLUMN IF NOT EXISTS approved_by text;
+ALTER TABLE public.access_requests ADD COLUMN IF NOT EXISTS dismissed_reason text;


### PR DESCRIPTION
Implements #3 — Approve/Dismiss queue for access requests in the superuser admin dash.

## What changed

- **Migration `035_access_requests_admin_queue.sql`**: adds `approved_by` and `dismissed_reason` to `access_requests` — only the two columns this issue owns per the coordination contract in migration 033's header. `IF NOT EXISTS`-safe, not yet applied to any database.
- **`api/_admin-action.js`**: new `approve_access_request` / `dismiss_access_request` actions inside the existing dispatch (no new routed function — we're near the Vercel 12-function limit). Both claim the row with a conditional `status=eq.pending` update, so double-clicks and concurrent tabs act exactly once. Approve calls the shared `provisionTrialAccess()` from `api/_provision.js` (same path as promo auto-approve); if provisioning refuses (e.g. `existing_user`) the claim is released back to `pending` and the reason is returned. Dismiss records who/when/why; no email. Superuser gating unchanged.
- **`api/admin.js`**: pending access requests (newest first) added to the admin data payload plus a `pending_access_requests` summary count; degrades to an empty list on query errors.
- **`src/components/SuperAdmin.jsx`**: "Access Requests" panel — count badge, Needs Attention entry, queue table (name/email, company, note + promo code, requested time), per-row busy state, dismiss confirmation with optional reason, optimistic removal with rollback + error toast.

Note: dismiss stamps the shared `approved_by`/`approved_at` pair (documented in the migration header as the generic "actioned by/at" columns) — the 033 contract left no dedicated dismissed-by columns.

## Testing

- `npm run lint` — at the staging baseline (zero new problems)
- `npm run test:lint` — 0 errors
- `npm run test:backtest` — 9/9 pass
- `npm run build` — succeeds

Manual on the preview (needs migration 035 applied to the staging database first):
- Non-superuser POST → 403; no panel rendered
- Approve a seeded pending row → one org + invitation + welcome email; row leaves the queue without reload; re-approve → no-op
- Dismiss → status + reason recorded, no email sent
- Approve an already-registered email → row returns to the queue with a visible error
- Existing admin panels (users/orgs/analytics) still load
