### PR TITLE
Tune Up: enable prompt caching in the proxy + endpoint latency telemetry (#27)

### DIFF
--- a/api/_guard.js
+++ b/api/_guard.js
@@ -311,6 +311,49 @@ function sanitizeSystemPrompt(system) {
   return SERVER_PREAMBLE + clean;
 }
 
+// ── PROMPT-CACHE BREAKPOINT (#27) ────────────────────────────────────────
+// Adds a cache_control breakpoint at the end of the last user message so the
+// full request prefix (tools → system → static instruction + schema body) is
+// cacheable. The brief pipeline's ~10k-token static prefix rides inside the
+// user message as a single text block, so a system-level breakpoint alone
+// never covers it — this is the breakpoint that makes identical re-runs and
+// the client retry ladder (which re-sends byte-identical bodies) hit cache.
+//
+// Cost/safety notes:
+// - Prompts below the model's minimum cacheable prefix (1024 tokens on
+//   Sonnet 4.6, 4096 on Haiku 4.5 / Opus 4.6) are silently NOT cached — no
+//   write premium, no behavior change.
+// - Cache reads/writes do not affect model output (temperature 0 + top_k 1
+//   determinism is preserved; rendered prompt bytes are unchanged — a single
+//   text block is API-equivalent to string content).
+// - Never mutates the client's message objects; returns a new array.
+function addMessagesCacheBreakpoint(messages) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg || msg.role !== "user") continue; // skip trailing assistant prefill ("{")
+    if (typeof msg.content === "string") {
+      if (!msg.content) return messages; // empty — leave for upstream validation
+      const marked = {
+        ...msg,
+        content: [{ type: "text", text: msg.content, cache_control: { type: "ephemeral" } }],
+      };
+      return messages.map((m, j) => (j === i ? marked : m));
+    }
+    if (Array.isArray(msg.content) && msg.content.length) {
+      const last = msg.content[msg.content.length - 1];
+      // Only mark a trailing text block; if the client already placed its own
+      // breakpoint, respect it (max 4 breakpoints per request).
+      if (!last || last.type !== "text" || last.cache_control) return messages;
+      const content = msg.content
+        .slice(0, -1)
+        .concat([{ ...last, cache_control: { type: "ephemeral" } }]);
+      return messages.map((m, j) => (j === i ? { ...m, content } : m));
+    }
+    return messages;
+  }
+  return messages;
+}
+
 // ── BODY BUILDER ─────────────────────────────────────────────────────────
 export function buildAnthropicBody(body, { stream = false } = {}) {
   if (!body || typeof body !== "object") {
@@ -338,11 +381,19 @@ export function buildAnthropicBody(body, { stream = false } = {}) {
     max_tokens: Math.min(Number(body.max_tokens) || 1024, MAX_TOKENS_CAP),
     temperature: 0,
     top_k: 1, // Deterministic: always pick the most likely token
-    messages: body.messages,
+    messages: addMessagesCacheBreakpoint(body.messages),
   };
   if (typeof body.system === "string" && body.system.length && body.system.length <= 30_000) {
-    // Plain string system — prepend SERVER_PREAMBLE and sanitize (existing behavior)
-    clean.system = sanitizeSystemPrompt(body.system);
+    // Plain string system — prepend SERVER_PREAMBLE and sanitize (existing
+    // behavior), emitted as a single cached block (#27). A one-element text
+    // block array renders byte-identically to the string form, so model input
+    // is unchanged; the cache_control breakpoint marks the end of the static
+    // anti-hallucination prefix so tools + system participate in the cache.
+    clean.system = [{
+      type: "text",
+      text: sanitizeSystemPrompt(body.system),
+      cache_control: { type: "ephemeral" },
+    }];
   } else if (Array.isArray(body.system) && body.system.length) {
     // Array of content blocks — used for prompt caching (cache_control: { type: "ephemeral" })
     // Sanitize each block's text through injection filter; SERVER_PREAMBLE is prepended as first block.

--- a/scripts/daily-health.mjs
+++ b/scripts/daily-health.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// scripts/daily-health.mjs — Daily API health check from api_usage_log (#27)
+//
+// Reports per-endpoint latency percentiles (p50/p95), slow-call counts, and
+// prompt-cache hit rates so speed regressions and cache effectiveness are
+// queryable without the SuperAdmin dashboard.
+//
+// Usage:
+//   node scripts/daily-health.mjs               # last 1 day
+//   node scripts/daily-health.mjs --days=7      # last 7 days
+//   node scripts/daily-health.mjs --by-model    # additionally split by model
+//
+// Requires: SUPABASE_SERVICE_KEY (service_role — same as nightly-backup.mjs).
+// Optional: SUPABASE_URL / VITE_SUPABASE_URL to point at a different project
+// (defaults to the production project used by nightly-backup.mjs).
+// Reads .env.local / .env from the repo root if present.
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+for (const name of [".env.local", ".env"]) {
+  const p = join(ROOT, name);
+  if (!existsSync(p)) continue;
+  for (const line of readFileSync(p, "utf8").split("\n")) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (m && process.env[m[1]] === undefined) {
+      let val = m[2];
+      if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'")))
+        val = val.slice(1, -1);
+      process.env[m[1]] = val;
+    }
+  }
+}
+
+const SB_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || "https://xtnidawfuaxwwwcnkewu.supabase.co";
+const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
+if (!SB_KEY) {
+  console.error("SUPABASE_SERVICE_KEY not set. Get it from Supabase Dashboard → Settings → API → service_role key.");
+  process.exit(1);
+}
+
+const args = Object.fromEntries(process.argv.slice(2).map(a => {
+  const m = a.match(/^--([a-z-]+)(?:=(.*))?$/);
+  return m ? [m[1], m[2] ?? true] : [a, true];
+}));
+const DAYS = Math.max(1, parseInt(args.days, 10) || 1);
+const BY_MODEL = !!args["by-model"];
+const SLOW_MS = 60_000; // acceptance criterion for #27: no call >60s at p95
+
+const since = new Date(Date.now() - DAYS * 86_400_000).toISOString();
+
+function percentile(sorted, p) {
+  if (!sorted.length) return null;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)];
+}
+
+const fmtMs = v => v == null ? "—" : v >= 10_000 ? `${(v / 1000).toFixed(1)}s` : `${v}ms`;
+const pct = (n, d) => d ? `${((100 * n) / d).toFixed(1)}%` : "—";
+
+async function fetchRows() {
+  // Page through PostgREST results (default server cap is 1000 rows).
+  const rows = [];
+  const PAGE = 1000;
+  for (let offset = 0; ; offset += PAGE) {
+    const url = `${SB_URL}/rest/v1/api_usage_log` +
+      `?select=endpoint,model,duration_ms,input_tokens,cache_read_tokens,cache_creation_tokens,created_at` +
+      `&created_at=gte.${encodeURIComponent(since)}` +
+      `&order=created_at.desc&limit=${PAGE}&offset=${offset}`;
+    const res = await fetch(url, { headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}` } });
+    if (!res.ok) {
+      console.error(`api_usage_log query failed: ${res.status} — ${(await res.text()).slice(0, 200)}`);
+      process.exit(1);
+    }
+    const page = await res.json();
+    rows.push(...page);
+    if (page.length < PAGE || rows.length >= 100_000) break;
+  }
+  return rows;
+}
+
+function summarize(rows) {
+  const durations = rows.map(r => r.duration_ms).filter(v => Number.isFinite(v)).sort((a, b) => a - b);
+  const cacheReads = rows.filter(r => (r.cache_read_tokens || 0) > 0).length;
+  const cacheWrites = rows.filter(r => (r.cache_creation_tokens || 0) > 0).length;
+  return {
+    calls: rows.length,
+    withDuration: durations.length,
+    p50: percentile(durations, 50),
+    p95: percentile(durations, 95),
+    max: durations.length ? durations[durations.length - 1] : null,
+    slow: durations.filter(v => v > SLOW_MS).length,
+    cacheReads,
+    cacheWrites,
+  };
+}
+
+function printTable(title, groups) {
+  console.log(`\n--- ${title} ---`);
+  const header = ["group", "calls", "p50", "p95", "max", `>${SLOW_MS / 1000}s`, "cache-hit", "cache-write"];
+  const lines = [header];
+  for (const [name, s] of groups) {
+    lines.push([
+      name, String(s.calls), fmtMs(s.p50), fmtMs(s.p95), fmtMs(s.max),
+      String(s.slow), pct(s.cacheReads, s.calls), pct(s.cacheWrites, s.calls),
+    ]);
+  }
+  const widths = lines[0].map((_, i) => Math.max(...lines.map(l => l[i].length)));
+  for (const l of lines) console.log("  " + l.map((c, i) => c.padEnd(widths[i] + 2)).join(""));
+}
+
+async function main() {
+  console.log(`\n=== CAMBRIAN CATALYST DAILY HEALTH CHECK ===`);
+  console.log(`Window: last ${DAYS} day(s) (since ${since})`);
+  console.log(`Source: ${SB_URL} api_usage_log`);
+
+  const rows = await fetchRows();
+  if (!rows.length) {
+    console.log("\nNo api_usage_log rows in window — nothing to report.");
+    return;
+  }
+
+  // Overall
+  printTable("OVERALL", [["all", summarize(rows)]]);
+
+  // Per endpoint (p50/p95 duration_ms by endpoint — #27 measurement task)
+  const byEndpoint = new Map();
+  for (const r of rows) {
+    const key = r.endpoint || "unknown";
+    if (!byEndpoint.has(key)) byEndpoint.set(key, []);
+    byEndpoint.get(key).push(r);
+  }
+  printTable("BY ENDPOINT", [...byEndpoint.entries()]
+    .sort((a, b) => b[1].length - a[1].length)
+    .map(([k, v]) => [k, summarize(v)]));
+
+  if (BY_MODEL) {
+    const byModel = new Map();
+    for (const r of rows) {
+      const key = `${r.endpoint || "unknown"} / ${r.model || "unknown"}`;
+      if (!byModel.has(key)) byModel.set(key, []);
+      byModel.get(key).push(r);
+    }
+    printTable("BY ENDPOINT / MODEL", [...byModel.entries()]
+      .sort((a, b) => b[1].length - a[1].length)
+      .map(([k, v]) => [k, summarize(v)]));
+  }
+
+  // Long-pole detail: the 10 slowest calls in the window
+  const slowest = rows.filter(r => Number.isFinite(r.duration_ms))
+    .sort((a, b) => b.duration_ms - a.duration_ms).slice(0, 10);
+  console.log(`\n--- 10 SLOWEST CALLS ---`);
+  for (const r of slowest) {
+    console.log(`  ${fmtMs(r.duration_ms).padEnd(8)} ${(r.endpoint || "?").padEnd(14)} ${(r.model || "?").padEnd(28)} in:${r.input_tokens || 0} cacheRead:${r.cache_read_tokens || 0} ${r.created_at}`);
+  }
+  console.log("");
+}
+
+main().catch(e => { console.error("Health check failed:", e); process.exit(1); });


### PR DESCRIPTION
Implements #27 (partially, deliberately) — prompt caching that actually works, plus endpoint latency telemetry. The P1 stream split was intentionally **not** shipped; rationale below.

## Finding: prompt caching was effectively off

Both proxies send the `prompt-caching` beta header, but headers alone cache nothing — `cache_control` breakpoints are required in the body, and only the two ICP call sites ever set them. The entire p1–p9 brief pipeline, Milton, discovery, solution-fit — everything else — had **zero** caching. Worse, the ~10.9k static instruction/schema tokens ride inside the *user* message, so the issue's suggested system-prefix breakpoint alone would have been a silent no-op (below the 4096-token cache minimum on Haiku/Opus).

## What changed

1. **`d09fae6` — cache the static prefix centrally in `api/_guard.js`** (shared body builder for both `/api/claude` and `/api/claude-stream`): string-form system prompts become a single cached text block (byte-identical rendering — model input unchanged), and a second breakpoint lands on the final text block of the last user message, covering the full static prefix. Client-placed breakpoints (ICP path) are respected; below-minimum prompts are silently uncached (no write premium); messages are copied, never mutated. Verified with 6 request-shape tests. Determinism untouched — caching doesn't affect sampling.
2. **`ebc7808` — `scripts/daily-health.mjs`** (new): per-endpoint calls / p50 / p95 / max `duration_ms`, >60s slow-call counts, cache read/write rates, and the 10 slowest calls from `api_usage_log` (`--days=N`, `--by-model`; same service-role auth pattern as nightly-backup). No existing health script queried durations.

## Why the P1 split didn't ship

The P1 schema hard-couples firmographics to the search-derived ownership determination (`fundingProfile` MUST agree with `publicPrivate`/`companySnapshot`; revenue only assertable via the ownership check). A no-search firmographics fast path violates the P0 anti-fabrication doctrine (re-creating Root Cause 2 from docs/ROOT_CAUSE_ANALYSIS.md), and under forced temperature-0 a split provably cannot meet the issue's "final content identical to baseline" bar. P2 also blocks on P1's snapshot, and the account-select pre-cache consumes the same prompt. Per the issue's own conservative guidance, the cache + measurement work shipped instead.

## Testing

- `npm run lint` — at the staging baseline (zero new problems)
- `npm run test:lint` — 0 errors · `npm run test:backtest` — 9/9 · `npm run build` — succeeds

Manual on the preview:
- Two identical briefs back-to-back → 2nd-run rows show `cache_read_tokens > 0` and materially lower `duration_ms` (note: app-level pre-caches may skip p1/p2 on the 2nd run — compare a p3/p4-class call or clear app caches)
- No Anthropic 400s post-deploy (breakpoint plumbing) in `[claude]`/`[claude-stream]` logs
- `node scripts/daily-health.mjs --days=7 --by-model` with `SUPABASE_SERVICE_KEY` renders p50/p95 + cache rates
- Cost watch: above-minimum cache misses pay the 1.25× write premium (~+25% first-run input cost) until reads net it out
