### PR TITLE
Signup-flow gap fixes: silent queue path, email normalization, already-handled detection (#3)

### DIFF
--- a/api/_provision.js
+++ b/api/_provision.js
@@ -7,6 +7,8 @@
 
 const SB_URL = process.env.VITE_SUPABASE_URL;
 const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
+const RESEND_API_KEY = process.env.RESEND_API_KEY;
+const FROM_ADDR = "Cambree <noreply@cambree.ai>";
 
 async function sbFetch(path, method = "GET", body = null) {
   const headers = {
@@ -37,7 +39,39 @@ async function sendInviteEmail(email, invitationToken) {
 
   const authData = await authRes.json().catch(() => ({}));
   if (authRes.status === 422 || (authData.msg || "").includes("already been registered")) {
+    // Auth account already exists (prior partial invite). A bare recovery
+    // email reads as an out-of-the-blue "reset your password" — send a
+    // contextual approval email with an admin-generated recovery link when
+    // Resend is available, and fall back to the plain recovery template.
     try {
+      if (RESEND_API_KEY) {
+        const linkRes = await fetch(`${SB_URL}/auth/v1/admin/generate_link`, {
+          method: "POST",
+          headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}`, "Content-Type": "application/json" },
+          body: JSON.stringify({ type: "recovery", email }),
+        });
+        const linkData = await linkRes.json().catch(() => ({}));
+        const actionLink = linkData?.action_link;
+        if (actionLink) {
+          const mailRes = await fetch("https://api.resend.com/emails", {
+            method: "POST",
+            headers: { Authorization: `Bearer ${RESEND_API_KEY}`, "Content-Type": "application/json" },
+            body: JSON.stringify({
+              from: FROM_ADDR,
+              to: email,
+              subject: "Your Cambree access is approved — sign in",
+              text:
+                `Good news — your Cambree access request is approved.\n\n` +
+                `You already have an account with this address, so use the link below to set your password and sign in:\n\n` +
+                `${actionLink}\n\n` +
+                `If you have questions, just reply to this email.\n\n` +
+                `— The Cambree team`,
+            }),
+          });
+          if (mailRes.ok) return { emailSent: true, action: "existing_account_email" };
+          console.warn("[provision] Existing-account Resend failed:", mailRes.status);
+        }
+      }
       await fetch(`${SB_URL}/auth/v1/recover`, {
         method: "POST",
         headers: { apikey: SB_KEY, "Content-Type": "application/json" },

--- a/api/admin.js
+++ b/api/admin.js
@@ -84,7 +84,7 @@ export default async function handler(req, res) {
     // Fetch all data in parallel
     // sessionIndex: lightweight query of ALL sessions (no data blob) for accurate per-user counts
     // sessions: paginated with full data blob for session detail view
-    const [users, orgs, sessionIndex, sessions, usageLogs, guestLogs, dbCosts, accessRequestRows] = await Promise.all([
+    const [users, orgs, sessionIndex, sessions, usageLogs, guestLogs, dbCosts, accessRequestRows, invitationRows] = await Promise.all([
       sbFetch("users?select=id,email,name,role,org_id,created_at,last_login&order=created_at.desc"),
       sbFetch("orgs?select=id,name,seller_url,plan,run_count,run_limit,max_run_count,max_run_limit,created_at&order=created_at.desc"),
       // ALL sessions — lightweight (no data blob) for accurate user activity stats
@@ -97,10 +97,22 @@ export default async function handler(req, res) {
       fetch(`${SB_URL}/rest/v1/rpc/get_cost_summary`, { method: "POST", headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}`, "Content-Type": "application/json" }, body: "{}" }).then(r => r.json()).catch(() => null),
       // Pending beta access requests for the Approve/Dismiss queue (issue #3)
       sbFetch("access_requests?status=eq.pending&select=id,name,email,company,note,promo_code,created_at&order=created_at.desc").catch(() => []),
+      // Invitation emails for "already handled" detection on the queue
+      sbFetch("invitations?select=email,accepted_at").catch(() => []),
     ]);
 
-    // PostgREST errors come back as an object, not an array — treat as empty
-    const accessRequests = Array.isArray(accessRequestRows) ? accessRequestRows : [];
+    // PostgREST errors come back as an object, not an array — treat as empty.
+    // Requests whose email already belongs to a user (or has an outstanding
+    // invitation) were handled out-of-band — the queue flags them so Approve
+    // isn't offered on a row that would just bounce with existing_user.
+    const userEmailSet = new Set((Array.isArray(users) ? users : []).map(u => (u.email || "").toLowerCase()));
+    const inviteEmailSet = new Set((Array.isArray(invitationRows) ? invitationRows : [])
+      .filter(i => !i.accepted_at).map(i => (i.email || "").toLowerCase()));
+    const accessRequests = (Array.isArray(accessRequestRows) ? accessRequestRows : []).map(r => ({
+      ...r,
+      already_user: userEmailSet.has((r.email || "").trim().toLowerCase()),
+      invite_pending: inviteEmailSet.has((r.email || "").trim().toLowerCase()),
+    }));
 
     // Build user activity map
     const now = Date.now();

--- a/api/request-access.js
+++ b/api/request-access.js
@@ -80,12 +80,42 @@ async function notifyFounder({ name, email, company, note, created_at, extra }) 
           (note ? `Note:    ${note}\n` : "") +
           (extra ? `Flag:    ${extra}\n` : "") +
           `When:    ${created_at}\n\n` +
-          `Send them an invite from Supabase Auth if approved.`,
+          // A Supabase-dashboard auth invite carries no invitation_token and
+          // creates no org — the user would land with broken onboarding. The
+          // admin queue (or the in-app invite flow) provisions correctly.
+          `Approve or dismiss it from Reporting → Access Requests in the app.`,
       }),
     });
     if (!r.ok) console.warn("[request-access] Resend responded", r.status, await r.text().catch(() => ""));
   } catch (e) {
     console.warn("[request-access] Resend call failed:", e.message);
+  }
+}
+
+// Acknowledgment to the requester on the queued path — without it the manual
+// path is completely silent until a human approves (issue #3 gap analysis).
+async function notifyRequester({ name, email }) {
+  if (!RESEND_API_KEY) return;
+  const firstName = (name || "").trim().split(/\s+/)[0] || "there";
+  try {
+    const r = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${RESEND_API_KEY}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        from: FROM_ADDR,
+        to: email,
+        subject: "We got your Cambree access request",
+        text:
+          `Hi ${firstName},\n\n` +
+          `Thanks for requesting access to the Cambree private beta. A human reviews every request personally — ` +
+          `when yours is approved you'll get an invite email from this address with a link to set up your account.\n\n` +
+          `No action needed in the meantime. If you have questions, just reply to this email.\n\n` +
+          `— The Cambree team`,
+      }),
+    });
+    if (!r.ok) console.warn("[request-access] Requester ack Resend responded", r.status, await r.text().catch(() => ""));
+  } catch (e) {
+    console.warn("[request-access] Requester ack failed:", e.message);
   }
 }
 
@@ -172,11 +202,13 @@ export default async function handler(req, res) {
     // Provisioning refused (existing user, etc.) — queue for a human instead.
     console.warn("[request-access] Promo provisioning fell back to queue:", prov.reason);
     await notifyFounder({ name, email: cleanEmail, company, note, created_at, extra: `Valid promo code, but auto-provision failed (${prov.reason}) — approve manually.` });
+    await notifyRequester({ name, email: cleanEmail });
     return res.json({ ok: true, approved: false, message: QUEUED_MSG });
   }
 
   // Manual queue path (no code, or code not recognized)
   await notifyFounder({ name, email: cleanEmail, company, note, created_at, extra: code ? "Submitted an unrecognized promo code." : null });
+  await notifyRequester({ name, email: cleanEmail });
 
   // Always succeed for the user once validated — email/DB failures are logged, not surfaced.
   return res.json({ ok: true, approved: false, message: code ? BAD_CODE_MSG : QUEUED_MSG });

--- a/api/request-access.js
+++ b/api/request-access.js
@@ -111,6 +111,11 @@ export default async function handler(req, res) {
   const code = typeof promoCode === "string" ? promoCode.trim() : "";
   if (code.length > 64) return res.status(400).json({ error: "Input too long" });
 
+  // Normalize: auth + users.email are lowercase, and the dedup/queue matching
+  // must treat Louis.Ruiz@ and louis.ruiz@ as the same requester (observed
+  // duplicate in production, 2026-08-11).
+  const cleanEmail = email.trim().toLowerCase();
+
   const created_at = new Date().toISOString();
 
   // Idempotency: if the same email was already submitted within the last 15
@@ -119,7 +124,7 @@ export default async function handler(req, res) {
   const idempotencyWindow = new Date(Date.now() - 15 * 60 * 1000).toISOString();
   try {
     const dupCheck = await sbRest(
-      `access_requests?email=eq.${encodeURIComponent(email.trim())}&created_at=gte.${encodeURIComponent(idempotencyWindow)}&select=id,status&limit=1`
+      `access_requests?email=eq.${encodeURIComponent(cleanEmail)}&created_at=gte.${encodeURIComponent(idempotencyWindow)}&select=id,status&limit=1`
     );
     if (dupCheck.ok) {
       const rows = await dupCheck.json();
@@ -142,7 +147,7 @@ export default async function handler(req, res) {
   let requestId = null;
   try {
     const insRes = await sbRest("access_requests", "POST",
-      { name, email, company, note: note || null, status: "pending", created_at, promo_code: code || null },
+      { name, email: cleanEmail, company, note: note || null, status: "pending", created_at, promo_code: code || null },
       "return=representation");
     if (insRes.ok) {
       const rows = await insRes.json().catch(() => null);
@@ -153,7 +158,7 @@ export default async function handler(req, res) {
   }
 
   if (codeRedeemed) {
-    const prov = await provisionTrialAccess({ email, name, company, invitedBy: "system:promo", promoCode: code });
+    const prov = await provisionTrialAccess({ email: cleanEmail, name, company, invitedBy: "system:promo", promoCode: code });
     if (prov.ok) {
       if (requestId) {
         try {
@@ -166,12 +171,12 @@ export default async function handler(req, res) {
     }
     // Provisioning refused (existing user, etc.) — queue for a human instead.
     console.warn("[request-access] Promo provisioning fell back to queue:", prov.reason);
-    await notifyFounder({ name, email, company, note, created_at, extra: `Valid promo code, but auto-provision failed (${prov.reason}) — approve manually.` });
+    await notifyFounder({ name, email: cleanEmail, company, note, created_at, extra: `Valid promo code, but auto-provision failed (${prov.reason}) — approve manually.` });
     return res.json({ ok: true, approved: false, message: QUEUED_MSG });
   }
 
   // Manual queue path (no code, or code not recognized)
-  await notifyFounder({ name, email, company, note, created_at, extra: code ? "Submitted an unrecognized promo code." : null });
+  await notifyFounder({ name, email: cleanEmail, company, note, created_at, extra: code ? "Submitted an unrecognized promo code." : null });
 
   // Always succeed for the user once validated — email/DB failures are logged, not surfaced.
   return res.json({ ok: true, approved: false, message: code ? BAD_CODE_MSG : QUEUED_MSG });

--- a/src/components/SuperAdmin.jsx
+++ b/src/components/SuperAdmin.jsx
@@ -1220,6 +1220,8 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                           <td>
                             <div style={{ fontWeight: 700, color: "var(--ink-0)", fontSize: 13 }}>{rq.name}</div>
                             <div style={{ fontSize: 11, color: "var(--ink-3)", marginTop: 1 }}>{rq.email}</div>
+                            {rq.already_user && <span className="admin-badge" style={{ background: "var(--violet-bg)", color: "var(--violet)", marginTop: 3 }}>Already a user</span>}
+                            {!rq.already_user && rq.invite_pending && <span className="admin-badge" style={{ background: "var(--amber-bg, var(--bg-1))", color: "var(--amber)", marginTop: 3 }}>Invite already sent</span>}
                           </td>
                           <td style={{ color: "var(--ink-1)", fontSize: 12 }}>{rq.company}</td>
                           <td style={{ fontSize: 11, color: "var(--ink-2)", maxWidth: 260 }}>
@@ -1229,10 +1231,20 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                           <td style={{ fontSize: 11, color: "var(--ink-3)", whiteSpace: "nowrap" }} title={rq.created_at}>{timeAgo(rq.created_at)}</td>
                           <td>
                             <div style={{ display: "flex", gap: 6 }}>
+                              {rq.already_user ? (
+                                <button disabled={busy} onClick={() => {
+                                  if (!window.confirm(`${rq.email} already has an account. Mark this request resolved? No email will be sent.`)) return;
+                                  actOnRequest(rq, "dismiss_access_request", "already handled — account exists");
+                                }}
+                                  style={{ padding: "5px 12px", borderRadius: 6, border: "none", background: "var(--violet)", color: "var(--surface)", fontSize: 11, fontWeight: 700, cursor: busy ? "default" : "pointer", opacity: busy ? 0.6 : 1 }}>
+                                  {busy ? "Working..." : "Mark Resolved"}
+                                </button>
+                              ) : (
                               <button disabled={busy} onClick={() => actOnRequest(rq, "approve_access_request")}
                                 style={{ padding: "5px 12px", borderRadius: 6, border: "none", background: "var(--green)", color: "var(--surface)", fontSize: 11, fontWeight: 700, cursor: busy ? "default" : "pointer", opacity: busy ? 0.6 : 1 }}>
-                                {busy ? "Working..." : "Approve"}
+                                {busy ? "Working..." : rq.invite_pending ? "Re-send Invite" : "Approve"}
                               </button>
+                              )}
                               <button disabled={busy} onClick={() => {
                                 const reason = window.prompt(`Dismiss the request from ${rq.email}? No email will be sent.\n\nOptional reason (OK to confirm, Cancel to abort):`);
                                 if (reason === null) return; // cancelled


### PR DESCRIPTION
Closes the signup-flow gaps documented in #3's gap analysis (2026-08-12). Stacked on the #3 queue branch (base: `feature/issue-3-access-queue`) because the queue-UI changes build on PR #42's panel — when #42 merges, this retargets to `staging`.

## What changed

1. **`9b83276` — email normalization** (`api/request-access.js`): requester emails are lowercased/trimmed before the 15-minute dedup check and the `access_requests` insert, so `Louis.Ruiz@…` and `louis.ruiz@…` are the same requester (the observed prod duplicate). Promo provisioning and founder notification get the normalized address too.
2. **`e0a388d` — the queued path is no longer silent** (`api/request-access.js`): requesters now get a "We got your Cambree access request" acknowledgment via Resend on both the manual-queue and promo-fallback paths (promo successes still get the invite email only). The founder notification no longer says "Send them an invite from Supabase Auth" — a dashboard invite carries no invitation token and creates no org — it now points at Reporting → Access Requests.
3. **`281d43c` — no more context-free password resets** (`api/_provision.js`): when approval hits an existing auth account (prior partial invite), we generate a recovery link via the GoTrue admin API and send a proper "Your Cambree access is approved — sign in" email through Resend, falling back to the plain recovery template only if that fails. New action tag: `existing_account_email`.
4. **`7e8d6a4` — already-handled detection in the queue** (`api/admin.js`, `src/components/SuperAdmin.jsx`): pending rows are annotated server-side (`already_user` from the users table, `invite_pending` from unaccepted invitations, both case-insensitive). The queue shows an "Already a user" badge with **Mark Resolved** (dismisses with a canned audit reason — no dead-end Approve that would bounce with `existing_user`), and "Invite already sent" rows offer **Re-send Invite** (the provisioning helper re-sends the existing token).

## Ops changes applied alongside (config, not code)

- Prod Supabase `site_url` updated `www.cambriancatalyst.ai` → `https://www.cambree.ai` (allow-list already contained both cambree.ai variants; old domains kept). Auth email links no longer depend on the legacy domain's redirect.
- The 15 stale pending rows in prod are left for the queue UI — with this PR they'll show correct badges (e.g. Louis Ruiz → "Already a user" → Mark Resolved).

## Testing

- `npm run test:lint` — 0 errors · `npm run test:backtest` — 9/9 · `npm run build` — succeeds
- Lint: **one** new instance of the pre-existing `no-undef 'process'` class (the new env read in `_provision.js` — `api/` lacks Node globals in `eslint.config.js`, same as its neighboring lines). No other new problems. Fixing the config would clear a large slice of the 284 legacy errors and belongs in its own change.

Manual on the preview:
- Submit a request with no code → on-screen confirmation **and** acknowledgment email arrives; founder email shows the new instruction line
- Submit the same email in different casing within 15 min → deduped (no second row)
- Approve a request whose email already has an unaccepted invitation → invite re-sent with the existing token
- Approve/queue a request for an email with an existing auth account → "access is approved — sign in" email (not a bare reset)
- Queue rows for existing users show the badge + Mark Resolved; resolved rows record the canned reason in `dismissed_reason`
