### PR TITLE
Admin API: optional ADMIN_EMAILS allowlist alongside SUPERUSER_EMAIL (#54)

### DIFF
--- a/api/_admin-action.js
+++ b/api/_admin-action.js
@@ -11,6 +11,17 @@ const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
 const SUPERUSER_EMAIL = process.env.SUPERUSER_EMAIL;
 if (!SUPERUSER_EMAIL) console.warn("[admin-action] SUPERUSER_EMAIL not set — all admin actions will be rejected");
 
+// Optional additional admins (comma-separated) alongside SUPERUSER_EMAIL —
+// lets a second operator use the Reporting dashboard without replacing the
+// primary superuser (issue #54).
+const ADMIN_EMAIL_SET = new Set(
+  [SUPERUSER_EMAIL, ...(process.env.ADMIN_EMAILS || "").split(",")]
+    .map(e => (e || "").trim().toLowerCase()).filter(Boolean)
+);
+export function isAdminEmail(email) {
+  return !!email && ADMIN_EMAIL_SET.has(email.toLowerCase());
+}
+
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 async function sbFetch(path, method = "GET", body = null) {
@@ -48,10 +59,10 @@ export default async function handler(req, res) {
   const payload = decodeJwtPayload(authToken);
   if (!payload?.sub || !UUID_RE.test(payload.sub)) return res.status(401).json({ error: "Authentication required" });
 
-  // Verify superuser — email must match SUPERUSER_EMAIL
+  // Verify admin — SUPERUSER_EMAIL or the optional ADMIN_EMAILS allowlist
   const userRes = await sbFetch(`users?id=eq.${payload.sub}&select=email`);
   const callerEmail = userRes?.[0]?.email;
-  if (!SUPERUSER_EMAIL || callerEmail?.toLowerCase() !== SUPERUSER_EMAIL.toLowerCase()) return res.status(403).json({ error: "Forbidden" });
+  if (!SUPERUSER_EMAIL || !isAdminEmail(callerEmail)) return res.status(403).json({ error: "Forbidden" });
 
   const { action, email, userId, orgId } = req.body || {};
   if (!email) return res.status(400).json({ error: "Email required" });

--- a/api/admin.js
+++ b/api/admin.js
@@ -25,7 +25,7 @@ async function sbFetch(path, maxRows = 10000) {
   return r.json();
 }
 
-import adminActionHandler from "./_admin-action.js";
+import adminActionHandler, { isAdminEmail } from "./_admin-action.js";
 
 export default async function handler(req, res) {
   // Route POST requests to admin-action handler (consolidated to stay within Vercel 12-function limit)
@@ -52,10 +52,10 @@ export default async function handler(req, res) {
   const payload = decodeJwtPayload(authToken);
   if (!payload?.sub || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(payload.sub)) return res.status(401).json({ error: "Authentication required" });
 
-  // Look up the caller's email — must match SUPERUSER_EMAIL
+  // Look up the caller's email — SUPERUSER_EMAIL or the ADMIN_EMAILS allowlist
   const userRes = await sbFetch(`users?id=eq.${payload.sub}&select=email`);
   const callerEmail = userRes?.[0]?.email;
-  if (!SUPERUSER_EMAIL || callerEmail?.toLowerCase() !== SUPERUSER_EMAIL.toLowerCase()) {
+  if (!SUPERUSER_EMAIL || !isAdminEmail(callerEmail)) {
     return res.status(403).json({ error: "Forbidden" });
   }
 


### PR DESCRIPTION
Implements #54 — a second operator can use the Reporting dashboard without replacing the primary superuser.

## What changed

`api/_admin-action.js` builds an admin set from `SUPERUSER_EMAIL` plus the optional comma-separated `ADMIN_EMAILS` env var (case-insensitive, whitespace-tolerant) and exports `isAdminEmail()`; both the dashboard GET (`api/admin.js`) and every admin action use it. With `ADMIN_EMAILS` unset, behavior is byte-for-byte the old single-superuser check. `SUPERUSER_EMAIL` itself is untouched everywhere, including audit stamps (`approved_by` records the actual caller).

Env: `ADMIN_EMAILS=joseph.hare@gmail.com` has been added to Vercel (Production + Preview).

## Testing

- `npm run test:lint` — 0 errors · `npm run test:backtest` — 9/9 · `npm run build` — succeeds
- Lint: one new instance of the pre-existing `no-undef 'process'` class (the new env read; `api/` lacks Node globals in the ESLint config) — no other new problems

Manual on the preview: caller in `ADMIN_EMAILS` loads the dashboard and can approve/dismiss; a non-listed org admin still gets 403; primary superuser unaffected.