### PR TITLE
Fix reset links landing on homepage: auth-action hash wins over stored session (#61)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4173,21 +4173,37 @@ function PasswordGate({ onAuth }) {
   React.useEffect(()=>{ setErr(""); },[mode]);
 
   React.useEffect(()=>{
-    // Check for Supabase auth redirects in URL hash
+    // Check for Supabase auth redirects in URL hash. When one is present it
+    // must WIN over any stored session: restoring (or refreshing) a prior
+    // session below would switch to the main app and the set-password form
+    // would never render — the observed "reset link lands on the homepage"
+    // bug. The single-use recovery token gets burned each attempt, so the
+    // user can never escape without clearing site data.
+    let authActionHandled = false;
     const hash = window.location.hash;
     if (hash) {
       const hashParams = new URLSearchParams(hash.replace("#", ""));
       const accessToken = hashParams.get("access_token");
       const type = hashParams.get("type");
+      const errCode = hashParams.get("error_code") || hashParams.get("error");
 
       if (accessToken && type === "recovery") {
         // Password reset flow
+        authActionHandled = true;
         setRecoveryToken(accessToken);
         setMode("newpassword");
+        window.history.replaceState({}, "", window.location.pathname);
+      } else if (!accessToken && errCode) {
+        // Expired or already-used link (e.g. error_code=otp_expired) — land on
+        // the reset form with an explanation instead of a silent homepage.
+        authActionHandled = true;
+        setMode("reset");
+        setErr("That link has expired or was already used. Enter your email to request a fresh one.");
         window.history.replaceState({}, "", window.location.pathname);
       } else if (accessToken && (type === "invite" || type === "signup" || type === "magiclink")) {
         // Invite flow — user clicked invite email link, Supabase created the account
         // They have a valid token but need to set a password
+        authActionHandled = true;
         setRecoveryToken(accessToken); // reuse recovery token for password setting
         setMode("invite_setpassword");
         // Try to extract email from the token payload
@@ -4225,6 +4241,10 @@ function PasswordGate({ onAuth }) {
 
     // Clear any legacy password-gate session data
     sessionStorage.removeItem('cambrian_auth');
+
+    // An explicit auth action (reset / invite / expired-link notice) takes
+    // precedence — skip session restore so its form actually renders.
+    if (authActionHandled) return;
 
     const restored = sbRestoreSession();
     if (restored?.needsRefresh) {


### PR DESCRIPTION
Fixes #61 — reported by a production user: password reset links redirected to the homepage without prompting for a new password.

## Root cause

The auth gate's startup effect parses the recovery hash and sets the set-password mode, then **unconditionally restores any stored session** in the same effect. Prior sign-ins leave `sb_refresh_token` + a stale expiry in localStorage, so the `needsRefresh` path refreshes and calls `onAuth()` — the app switches to the main UI and the set-password form never renders. Each click also burns the single-use recovery token, so retries can never succeed. Expired/re-used links redirect back with `#error_code=otp_expired`, which was silently ignored.

## What changed (`src/App.jsx`, auth gate effect)

- An auth-action hash (`type=recovery|invite|signup|magiclink` with `access_token`) now skips session restore for that page load — the explicit action wins; the form renders; setting the password establishes the fresh session as before.
- An error hash without a token (e.g. `otp_expired`) lands on the reset form with "That link has expired or was already used. Enter your email to request a fresh one." instead of a silent homepage.
- Normal loads (no auth hash) restore sessions exactly as before; referral (`?ref=`) and invitation (`?token=`) query handling is unaffected.

## Testing

- `npm run lint` (App.jsx) — identical problem count to the staging baseline
- `npm run test:lint` — 0 errors · `npm run test:backtest` — 9/9 · `npm run build` — succeeds

Manual on the preview:
- Sign in, then open a fresh reset link in the same browser → set-password form appears (previously: homepage)
- Open an already-used reset link → reset form with the expired-link message
- Invite link with a prior session in the browser → set-password invite form
- Plain visit with a valid session → restored to the app as usual