### PR TITLE
Static apply job name in terraform workflow (#73)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -107,7 +107,9 @@ jobs:
             }
 
   apply:
-    name: apply (${{ github.ref_name == 'main' && 'prod' || github.ref_name }})
+    # Static name: expressions in a skipped job's name render unevaluated in
+    # the PR checks list. The target env shows in the run's environment badge.
+    name: apply
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     # Binding to the GitHub Environment is what makes the deploy role


### PR DESCRIPTION
Follow-up to #74: gives the terraform apply job a static `name` — GitHub renders name expressions unevaluated (raw `${{ }}`) for jobs skipped in the PR checks list. The target env remains visible via the run's environment badge and logs. Same commit is riding to staging on #75. Part of #73.