### PR TITLE
Trust both casings of the production GitHub Environment (#73)

### DIFF
--- a/infra/github-oidc/modules/github-account/main.tf
+++ b/infra/github-oidc/modules/github-account/main.tf
@@ -113,14 +113,14 @@ data "aws_iam_policy_document" "deploy_trust" {
     condition {
       test     = "StringEquals"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["${var.github_sub_prefix}:environment:${var.github_environment}"]
+      values   = [for env in var.github_environments : "${var.github_sub_prefix}:environment:${env}"]
     }
   }
 }
 
 resource "aws_iam_role" "deploy" {
   name               = "github-deploy"
-  description        = "Terraform apply role for merges deploying the ${var.github_environment} environment (GitHub OIDC)"
+  description        = "Terraform apply role for merges deploying the ${var.github_environments[0]} environment (GitHub OIDC)"
   assume_role_policy = data.aws_iam_policy_document.deploy_trust.json
 }
 

--- a/infra/github-oidc/modules/github-account/variables.tf
+++ b/infra/github-oidc/modules/github-account/variables.tf
@@ -8,7 +8,7 @@ variable "env_slug" {
   type        = string
 }
 
-variable "github_environment" {
-  description = "GitHub Environment name the deploy role trusts (dev/staging/production)"
-  type        = string
+variable "github_environments" {
+  description = "GitHub Environment names the deploy role trusts (exact-match, OR'd — multiple entries cover casing variants of the same environment)"
+  type        = list(string)
 }

--- a/infra/github-oidc/oidc.tf
+++ b/infra/github-oidc/oidc.tf
@@ -5,25 +5,25 @@ module "dev" {
   source    = "./modules/github-account"
   providers = { aws = aws.dev }
 
-  github_sub_prefix  = local.github_sub_prefix
-  env_slug           = "dev"
-  github_environment = var.accounts["dev"].github_environment
+  github_sub_prefix   = local.github_sub_prefix
+  env_slug            = "dev"
+  github_environments = var.accounts["dev"].github_environments
 }
 
 module "staging" {
   source    = "./modules/github-account"
   providers = { aws = aws.staging }
 
-  github_sub_prefix  = local.github_sub_prefix
-  env_slug           = "staging"
-  github_environment = var.accounts["staging"].github_environment
+  github_sub_prefix   = local.github_sub_prefix
+  env_slug            = "staging"
+  github_environments = var.accounts["staging"].github_environments
 }
 
 module "prod" {
   source    = "./modules/github-account"
   providers = { aws = aws.prod }
 
-  github_sub_prefix  = local.github_sub_prefix
-  env_slug           = "prod"
-  github_environment = var.accounts["prod"].github_environment
+  github_sub_prefix   = local.github_sub_prefix
+  env_slug            = "prod"
+  github_environments = var.accounts["prod"].github_environments
 }

--- a/infra/github-oidc/variables.tf
+++ b/infra/github-oidc/variables.tf
@@ -27,17 +27,21 @@ variable "accounts" {
     env slug => member account. Ids from infra/org `account_ids` output.
     - The slug (dev/staging/prod) names the infra/envs/<slug> directory and its
       state bucket cambree-<slug>-terraform-state-<id>.
-    - github_environment is the GitHub Environment name bound into the deploy
-      role's trust policy (note: prod's is "production", not "prod").
+    - github_environments are the GitHub Environment names the deploy role's
+      trust policy accepts (exact-match, OR'd). Prod lists both casings:
+      the workflow says "production" but GitHub matched it case-insensitively
+      onto the pre-existing Vercel "Production" environment, and IAM
+      StringEquals is case-sensitive — so trust whichever form the token's
+      sub claim presents.
   EOT
   type = map(object({
-    id                 = string
-    github_environment = string
+    id                  = string
+    github_environments = list(string)
   }))
   default = {
-    dev     = { id = "405034826234", github_environment = "dev" }
-    staging = { id = "865526619955", github_environment = "staging" }
-    prod    = { id = "062560095244", github_environment = "production" }
+    dev     = { id = "405034826234", github_environments = ["dev"] }
+    staging = { id = "865526619955", github_environments = ["staging"] }
+    prod    = { id = "062560095244", github_environments = ["production", "Production"] }
   }
 }
 


### PR DESCRIPTION
Repo-side of a fix already applied to the live IAM (laptop-only `infra/github-oidc/` layer, applied 2026-08-21, plan clean): the workflow's `environment: production` resolved case-insensitively onto the pre-existing Vercel **Production** environment, and IAM `StringEquals` is case-sensitive — so the prod `github-deploy` trust policy now accepts the sub claim in either casing (`environment:production` / `environment:Production`). Deploy-role trust for an env is now a list to support this.

Verified: the production apply run assumed `github-deploy` in 062560095244 after required-reviewer approval and applied cleanly.

Part of #73. Touches only `infra/github-oidc/` (no CI-applied paths), so no terraform workflow run will trigger — merging is bookkeeping to keep the repo matching live IAM. Promote dev → staging → main as usual.