### PR TITLE
Amplify hosting: Terraform module + per-env apps (issue #82)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -16,10 +16,10 @@ name: terraform
 on:
   pull_request:
     branches: [dev, staging, main]
-    paths: ["infra/envs/**"]
+    paths: ["infra/envs/**", "infra/modules/**"]
   push:
     branches: [dev, staging, main]
-    paths: ["infra/envs/**"]
+    paths: ["infra/envs/**", "infra/modules/**"]
 
 permissions:
   id-token: write # OIDC token for aws-actions/configure-aws-credentials
@@ -34,6 +34,11 @@ concurrency:
 
 env:
   TF_VERSION: "1.10.3" # matches .tool-versions; state is written by this minor
+  # GitHub PAT for the Amplify repo connection (infra/modules/amplify) — a
+  # GitHub credential, NOT an AWS one; the no-AWS-keys rule above stands.
+  # Only consumed when creating the Amplify app or rotating its connection;
+  # empty is fine otherwise (the module ignores drift on it).
+  TF_VAR_amplify_github_token: ${{ secrets.AMPLIFY_GITHUB_TOKEN }}
 
 jobs:
   plan:

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -1,0 +1,21 @@
+# Amplify Hosting custom headers (issue #82) - ported byte-for-byte from the
+# "headers" block in vercel.json; keep the two in sync while both hosts serve
+# the SPA. The CSP connect-src additions for calling the Vercel API
+# cross-origin land with issue #83.
+customHeaders:
+  - pattern: '**'
+    headers:
+      - key: Strict-Transport-Security
+        value: 'max-age=63072000; includeSubDomains; preload'
+      - key: X-Frame-Options
+        value: 'DENY'
+      - key: X-Content-Type-Options
+        value: 'nosniff'
+      - key: X-XSS-Protection
+        value: '1; mode=block'
+      - key: Referrer-Policy
+        value: 'strict-origin-when-cross-origin'
+      - key: Permissions-Policy
+        value: 'camera=(), microphone=(), geolocation=()'
+      - key: Content-Security-Policy
+        value: "default-src 'self'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://api.anthropic.com https://api.hubapi.com https://vercel.live; img-src 'self' data: https:; worker-src 'self' blob:; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"

--- a/infra/envs/dev/amplify.auto.tfvars
+++ b/infra/envs/dev/amplify.auto.tfvars
@@ -1,0 +1,6 @@
+# Client-safe values only - Vite bakes these into the public bundle.
+# Copy from the Vercel project's environment variables BEFORE merging;
+# the Supabase URL/anon key are public by design (RLS is the boundary).
+vite_supabase_url      = "" # TODO: https://<project-ref>.supabase.co
+vite_supabase_anon_key = "" # TODO: anon key from Vercel env / Supabase dashboard
+vite_app_url           = "" # after first apply: the amplify_branch_url output

--- a/infra/envs/dev/amplify.auto.tfvars
+++ b/infra/envs/dev/amplify.auto.tfvars
@@ -1,6 +1,6 @@
 # Client-safe values only - Vite bakes these into the public bundle.
 # Copy from the Vercel project's environment variables BEFORE merging;
 # the Supabase URL/anon key are public by design (RLS is the boundary).
-vite_supabase_url      = "" # TODO: https://<project-ref>.supabase.co
-vite_supabase_anon_key = "" # TODO: anon key from Vercel env / Supabase dashboard
+vite_supabase_url      = "https://akceiidofsiajrjtgone.supabase.co" # cambree-staging project
+vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFrY2VpaWRvZnNpYWpyanRnb25lIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODUyODE2OTgsImV4cCI6MjEwMDg1NzY5OH0.IFyk54T-pg1uWCEp3E1BO-kDHTIQXjgH23qImLYBehU"
 vite_app_url           = "" # after first apply: the amplify_branch_url output

--- a/infra/envs/dev/amplify.tf
+++ b/infra/envs/dev/amplify.tf
@@ -1,0 +1,51 @@
+# Amplify Hosting - dev account builds the `dev` branch (issue #82).
+
+variable "amplify_github_token" {
+  description = "GitHub PAT for the Amplify repo connection; CI injects it from the AMPLIFY_GITHUB_TOKEN Actions secret. See infra/modules/amplify/README.md."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "vite_supabase_url" {
+  description = "Supabase project URL (public; same project across envs - staging/dev share production Supabase). Fill in amplify.auto.tfvars from Vercel project settings."
+  type        = string
+  default     = ""
+}
+
+variable "vite_supabase_anon_key" {
+  description = "Supabase anon key (public by design). Fill in amplify.auto.tfvars."
+  type        = string
+  default     = ""
+}
+
+variable "vite_app_url" {
+  description = "Public app URL baked into the bundle. Pre-domains (#84) this is the Amplify default branch URL, known after first apply - set it then."
+  type        = string
+  default     = ""
+}
+
+module "amplify" {
+  source = "../../modules/amplify"
+
+  app_name            = "cambree-catalyst-dev"
+  branch_name         = "dev"
+  branch_stage        = "DEVELOPMENT"
+  github_access_token = var.amplify_github_token
+
+  environment_variables = {
+    VITE_SUPABASE_URL      = var.vite_supabase_url
+    VITE_SUPABASE_ANON_KEY = var.vite_supabase_anon_key
+    VITE_APP_URL           = var.vite_app_url
+  }
+}
+
+output "amplify_app_id" {
+  description = "Amplify app id (record in docs/aws-migration-plan.md)"
+  value       = module.amplify.app_id
+}
+
+output "amplify_branch_url" {
+  description = "Where the dev SPA serves"
+  value       = module.amplify.branch_url
+}

--- a/infra/envs/prod/amplify.auto.tfvars
+++ b/infra/envs/prod/amplify.auto.tfvars
@@ -1,6 +1,6 @@
 # Client-safe values only - Vite bakes these into the public bundle.
 # Copy from the Vercel project's environment variables BEFORE merging;
 # the Supabase URL/anon key are public by design (RLS is the boundary).
-vite_supabase_url      = "" # TODO: https://<project-ref>.supabase.co
-vite_supabase_anon_key = "" # TODO: anon key from Vercel env / Supabase dashboard
+vite_supabase_url      = "https://xtnidawfuaxwwwcnkewu.supabase.co" # Cambrian Playbook project (live production data)
+vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inh0bmlkYXdmdWF4d3d3Y25rZXd1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU3Njc2NzEsImV4cCI6MjA5MTM0MzY3MX0.JPTyCbsLk9Kr4AHo3ynszOo_SxvLA-XpT_5TzP8M71o"
 vite_app_url           = "" # keep the Vercel value (https://cambree.ai) - prod links must point at the live site until the #85 cutover

--- a/infra/envs/prod/amplify.auto.tfvars
+++ b/infra/envs/prod/amplify.auto.tfvars
@@ -1,0 +1,6 @@
+# Client-safe values only - Vite bakes these into the public bundle.
+# Copy from the Vercel project's environment variables BEFORE merging;
+# the Supabase URL/anon key are public by design (RLS is the boundary).
+vite_supabase_url      = "" # TODO: https://<project-ref>.supabase.co
+vite_supabase_anon_key = "" # TODO: anon key from Vercel env / Supabase dashboard
+vite_app_url           = "" # keep the Vercel value (https://cambriancatalyst.ai) - prod links must point at the live site until the #85 cutover

--- a/infra/envs/prod/amplify.auto.tfvars
+++ b/infra/envs/prod/amplify.auto.tfvars
@@ -3,4 +3,4 @@
 # the Supabase URL/anon key are public by design (RLS is the boundary).
 vite_supabase_url      = "" # TODO: https://<project-ref>.supabase.co
 vite_supabase_anon_key = "" # TODO: anon key from Vercel env / Supabase dashboard
-vite_app_url           = "" # keep the Vercel value (https://cambriancatalyst.ai) - prod links must point at the live site until the #85 cutover
+vite_app_url           = "" # keep the Vercel value (https://cambree.ai) - prod links must point at the live site until the #85 cutover

--- a/infra/envs/prod/amplify.tf
+++ b/infra/envs/prod/amplify.tf
@@ -1,0 +1,51 @@
+# Amplify Hosting - prod account builds the `main` branch (issue #82).
+
+variable "amplify_github_token" {
+  description = "GitHub PAT for the Amplify repo connection; CI injects it from the AMPLIFY_GITHUB_TOKEN Actions secret. See infra/modules/amplify/README.md."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "vite_supabase_url" {
+  description = "Supabase project URL (public; same project across envs - staging/dev share production Supabase). Fill in amplify.auto.tfvars from Vercel project settings."
+  type        = string
+  default     = ""
+}
+
+variable "vite_supabase_anon_key" {
+  description = "Supabase anon key (public by design). Fill in amplify.auto.tfvars."
+  type        = string
+  default     = ""
+}
+
+variable "vite_app_url" {
+  description = "Public app URL baked into the bundle. Pre-domains (#84) this is the Amplify default branch URL, known after first apply - set it then."
+  type        = string
+  default     = ""
+}
+
+module "amplify" {
+  source = "../../modules/amplify"
+
+  app_name            = "cambree-catalyst"
+  branch_name         = "main"
+  branch_stage        = "PRODUCTION"
+  github_access_token = var.amplify_github_token
+
+  environment_variables = {
+    VITE_SUPABASE_URL      = var.vite_supabase_url
+    VITE_SUPABASE_ANON_KEY = var.vite_supabase_anon_key
+    VITE_APP_URL           = var.vite_app_url
+  }
+}
+
+output "amplify_app_id" {
+  description = "Amplify app id (record in docs/aws-migration-plan.md)"
+  value       = module.amplify.app_id
+}
+
+output "amplify_branch_url" {
+  description = "Where the prod SPA serves"
+  value       = module.amplify.branch_url
+}

--- a/infra/envs/staging/amplify.auto.tfvars
+++ b/infra/envs/staging/amplify.auto.tfvars
@@ -1,0 +1,6 @@
+# Client-safe values only - Vite bakes these into the public bundle.
+# Copy from the Vercel project's environment variables BEFORE merging;
+# the Supabase URL/anon key are public by design (RLS is the boundary).
+vite_supabase_url      = "" # TODO: https://<project-ref>.supabase.co
+vite_supabase_anon_key = "" # TODO: anon key from Vercel env / Supabase dashboard
+vite_app_url           = "" # after first apply: the amplify_branch_url output

--- a/infra/envs/staging/amplify.auto.tfvars
+++ b/infra/envs/staging/amplify.auto.tfvars
@@ -1,6 +1,6 @@
 # Client-safe values only - Vite bakes these into the public bundle.
 # Copy from the Vercel project's environment variables BEFORE merging;
 # the Supabase URL/anon key are public by design (RLS is the boundary).
-vite_supabase_url      = "" # TODO: https://<project-ref>.supabase.co
-vite_supabase_anon_key = "" # TODO: anon key from Vercel env / Supabase dashboard
+vite_supabase_url      = "https://akceiidofsiajrjtgone.supabase.co" # cambree-staging project
+vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFrY2VpaWRvZnNpYWpyanRnb25lIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODUyODE2OTgsImV4cCI6MjEwMDg1NzY5OH0.IFyk54T-pg1uWCEp3E1BO-kDHTIQXjgH23qImLYBehU"
 vite_app_url           = "" # after first apply: the amplify_branch_url output

--- a/infra/envs/staging/amplify.auto.tfvars
+++ b/infra/envs/staging/amplify.auto.tfvars
@@ -3,4 +3,4 @@
 # the Supabase URL/anon key are public by design (RLS is the boundary).
 vite_supabase_url      = "https://akceiidofsiajrjtgone.supabase.co" # cambree-staging project
 vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFrY2VpaWRvZnNpYWpyanRnb25lIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODUyODE2OTgsImV4cCI6MjEwMDg1NzY5OH0.IFyk54T-pg1uWCEp3E1BO-kDHTIQXjgH23qImLYBehU"
-vite_app_url           = "" # after first apply: the amplify_branch_url output
+vite_app_url           = "" # end-state https://staging.cambree.ai (live on Vercel today; set after the #84 domain flip). Until then: amplify_branch_url output

--- a/infra/envs/staging/amplify.tf
+++ b/infra/envs/staging/amplify.tf
@@ -1,0 +1,51 @@
+# Amplify Hosting - staging account builds the `staging` branch (issue #82).
+
+variable "amplify_github_token" {
+  description = "GitHub PAT for the Amplify repo connection; CI injects it from the AMPLIFY_GITHUB_TOKEN Actions secret. See infra/modules/amplify/README.md."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "vite_supabase_url" {
+  description = "Supabase project URL (public; same project across envs - staging/dev share production Supabase). Fill in amplify.auto.tfvars from Vercel project settings."
+  type        = string
+  default     = ""
+}
+
+variable "vite_supabase_anon_key" {
+  description = "Supabase anon key (public by design). Fill in amplify.auto.tfvars."
+  type        = string
+  default     = ""
+}
+
+variable "vite_app_url" {
+  description = "Public app URL baked into the bundle. Pre-domains (#84) this is the Amplify default branch URL, known after first apply - set it then."
+  type        = string
+  default     = ""
+}
+
+module "amplify" {
+  source = "../../modules/amplify"
+
+  app_name            = "cambree-catalyst-staging"
+  branch_name         = "staging"
+  branch_stage        = "BETA"
+  github_access_token = var.amplify_github_token
+
+  environment_variables = {
+    VITE_SUPABASE_URL      = var.vite_supabase_url
+    VITE_SUPABASE_ANON_KEY = var.vite_supabase_anon_key
+    VITE_APP_URL           = var.vite_app_url
+  }
+}
+
+output "amplify_app_id" {
+  description = "Amplify app id (record in docs/aws-migration-plan.md)"
+  value       = module.amplify.app_id
+}
+
+output "amplify_branch_url" {
+  description = "Where the staging SPA serves"
+  value       = module.amplify.branch_url
+}

--- a/infra/modules/amplify/README.md
+++ b/infra/modules/amplify/README.md
@@ -1,0 +1,38 @@
+# amplify module
+
+Amplify Hosting for the SPA - one app per account, building that account's
+environment branch (`dev` / `staging` / `main`). Instantiated from each
+`infra/envs/*` root and applied only by the Terraform CI pipeline (issue #73).
+Issue #82; background in docs/aws-migration-plan.md §1/§8 Phase 2.
+
+Security headers are NOT in Terraform: Amplify reads them from
+[`customHttp.yml`](../../../customHttp.yml) at the repo root on every deploy
+(the aws provider has no custom-headers argument). Header changes are code
+changes, reviewed like any other.
+
+## One-time manual setup (before the first apply per account)
+
+1. **Install the AWS Amplify GitHub App** for the target AWS account's
+   region when prompted by the connection flow, granting it access to
+   `Cambree-AI/cambrian-playbook` only.
+2. **Create a GitHub fine-grained PAT** scoped to this repository with
+   Contents: read-only, Metadata: read-only, and Webhooks: read and write.
+   (Classic-PAT fallback: `repo` + `admin:repo_hook`.) Amplify uses it once
+   to register the build webhook and read the repo; it is not needed after
+   app creation.
+3. **Store it as the GitHub Actions secret `AMPLIFY_GITHUB_TOKEN`**
+   (repository-level). The workflow injects it as
+   `TF_VAR_amplify_github_token`. This is a GitHub credential, not an AWS
+   one - the "no AWS keys in GitHub" rule (issue #73) still holds.
+4. After all three apps exist the secret can be rotated or removed; applies
+   with the variable unset are no-ops on the connection
+   (`ignore_changes = [access_token]`).
+
+## Environment variables
+
+`environment_variables` accepts **client-safe `VITE_*` values only** (module
+validation enforces the prefix). Vite bakes them into the public bundle:
+the Supabase URL + anon key are designed to be public; **no server secret
+(`ANTHROPIC_API_KEY`, `SUPABASE_SERVICE_KEY`, ...) may ever be set here.**
+Fill the values in each env root's `amplify.auto.tfvars` from the Vercel
+project settings before merging.

--- a/infra/modules/amplify/main.tf
+++ b/infra/modules/amplify/main.tf
@@ -1,0 +1,94 @@
+# Amplify Hosting for the Vite SPA (issue #82, migration Phase 2).
+#
+# One app per AWS account, building exactly one branch - the account's
+# environment branch (dev/staging/main) - preserving the account-isolation
+# model from issue #9. Rewrites are ported from vercel.json; security
+# headers live in customHttp.yml at the repo root (the aws provider does
+# not expose Amplify custom headers, and the YAML travels with the code).
+
+resource "aws_amplify_app" "this" {
+  name       = var.app_name
+  repository = var.repository_url
+  platform   = "WEB"
+
+  # GitHub PAT used only to register the repo webhook + read access at
+  # create/rotation time (see README.md). CI injects it via
+  # TF_VAR_amplify_github_token; an unset Actions secret arrives as "" and
+  # must become null so AWS never sees an empty token.
+  access_token = var.github_access_token == "" ? null : var.github_access_token
+
+  build_spec = <<-EOT
+    version: 1
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - nvm install 20
+            - npm ci
+        build:
+          commands:
+            - npm run build
+      artifacts:
+        baseDirectory: dist
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - node_modules/**/*
+  EOT
+
+  # Rewrites ported from vercel.json. Order matters: explicit rewrites
+  # first, SPA fallback last.
+  custom_rule {
+    source = "/privacy"
+    target = "/privacy.html"
+    status = "200"
+  }
+
+  custom_rule {
+    source = "/terms"
+    target = "/terms.html"
+    status = "200"
+  }
+
+  custom_rule {
+    source = "/support"
+    target = "/support.html"
+    status = "200"
+  }
+
+  custom_rule {
+    source = "/user-guide"
+    target = "/cambree-user-guide.pdf"
+    status = "200"
+  }
+
+  # SPA fallback: anything that is not a static asset (by extension) serves
+  # index.html. html/pdf stay excluded so /privacy.html and the user guide
+  # are served directly, matching Vercel behavior.
+  custom_rule {
+    source = "</^[^.]+$|\\.(?!(css|gif|ico|jpg|jpeg|js|json|map|mp4|pdf|png|svg|ttf|txt|webp|webmanifest|woff|woff2|xml|html)$)([^.]+$)/>"
+    target = "/index.html"
+    status = "200"
+  }
+
+  lifecycle {
+    # The API never returns the token, and applies without the secret set
+    # must not try to clear it.
+    ignore_changes = [access_token]
+  }
+}
+
+resource "aws_amplify_branch" "this" {
+  app_id      = aws_amplify_app.this.id
+  branch_name = var.branch_name
+  stage       = var.branch_stage
+  framework   = "React"
+
+  enable_auto_build = true
+
+  # Client-side (VITE_*) values only - Vite bakes these into the public
+  # bundle. Server secrets (ANTHROPIC_API_KEY etc.) must NEVER appear here;
+  # the v100 proxy rule stands.
+  environment_variables = var.environment_variables
+}

--- a/infra/modules/amplify/outputs.tf
+++ b/infra/modules/amplify/outputs.tf
@@ -1,0 +1,14 @@
+output "app_id" {
+  description = "Amplify app id"
+  value       = aws_amplify_app.this.id
+}
+
+output "default_domain" {
+  description = "Amplify default domain; the branch serves at <branch>.<this>"
+  value       = aws_amplify_app.this.default_domain
+}
+
+output "branch_url" {
+  description = "HTTPS URL the environment branch serves at (default domain)"
+  value       = "https://${aws_amplify_branch.this.branch_name}.${aws_amplify_app.this.default_domain}"
+}

--- a/infra/modules/amplify/variables.tf
+++ b/infra/modules/amplify/variables.tf
@@ -1,0 +1,44 @@
+variable "app_name" {
+  description = "Amplify app name (one app per account/environment)"
+  type        = string
+}
+
+variable "repository_url" {
+  description = "HTTPS URL of the GitHub repository Amplify builds from"
+  type        = string
+  default     = "https://github.com/Cambree-AI/cambrian-playbook"
+}
+
+variable "branch_name" {
+  description = "The single git branch this account's app builds (dev/staging/main)"
+  type        = string
+}
+
+variable "branch_stage" {
+  description = "Amplify stage label for the branch"
+  type        = string
+  default     = "PRODUCTION"
+
+  validation {
+    condition     = contains(["PRODUCTION", "BETA", "DEVELOPMENT", "EXPERIMENTAL"], var.branch_stage)
+    error_message = "branch_stage must be one of PRODUCTION, BETA, DEVELOPMENT, EXPERIMENTAL."
+  }
+}
+
+variable "github_access_token" {
+  description = "GitHub PAT for repo webhook registration; injected by CI as TF_VAR_amplify_github_token, only needed when creating the app or rotating the connection. See README.md."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "environment_variables" {
+  description = "Branch build env vars. Client-safe VITE_* values ONLY - these are baked into the public bundle."
+  type        = map(string)
+  default     = {}
+
+  validation {
+    condition     = alltrue([for k in keys(var.environment_variables) : startswith(k, "VITE_")])
+    error_message = "Only VITE_-prefixed (client-safe) variables are allowed; server secrets never go into Amplify env vars."
+  }
+}


### PR DESCRIPTION
Part of #82 (Amplify hosting, migration Phase 2). Terraform only — nothing applies until merge, and the dev apply will surface the one thing this PR can't verify statically: the Amplify↔GitHub connection.

## What this adds

- **`infra/modules/amplify/`** — one Amplify app per account building that account's env branch (`dev`/`staging`/`main`), Node 20 + Vite build to `dist/`, all five `vercel.json` rewrites as ordered `custom_rule`s (explicit rewrites first; SPA fallback excludes `html`/`pdf` so `/privacy.html` and the user guide serve directly). A module validation rejects any non-`VITE_` env var so server secrets can't reach the client bundle.
- **`customHttp.yml`** — security headers ported byte-for-byte from `vercel.json` (the aws provider has no custom-headers argument; Amplify reads this file per deploy). CSP `connect-src` changes for cross-origin API calls land with #83.
- **Env roots** — `cambree-catalyst-dev` / `cambree-catalyst-staging` / `cambree-catalyst` instantiated in `infra/envs/{dev,staging,prod}`; client-safe values ride `amplify.auto.tfvars`.
- **Workflow** — also triggers on `infra/modules/**`; injects `TF_VAR_amplify_github_token` from the `AMPLIFY_GITHUB_TOKEN` Actions secret (a GitHub PAT — the no-AWS-keys rule stands). Unset secret normalizes to `null`; `ignore_changes = [access_token]` keeps later applies quiet.

## Before merging (manual, see `infra/modules/amplify/README.md`)

1. Install the AWS Amplify GitHub App for this repo.
2. Create the fine-grained PAT (Contents/Metadata read, Webhooks read-write) → save as the `AMPLIFY_GITHUB_TOKEN` repository secret.
3. Fill `amplify.auto.tfvars` in all three env roots (Supabase URL + anon key — public-safe; prod `vite_app_url` stays `https://cambree.ai` until the #85 cutover).

## Verification

- `terraform fmt` clean; `terraform validate` green in all three env roots.
- Workflow + customHttp YAML parse.
- After the dev merge: Amplify builds the `dev` branch; SPA loads at the default domain; rewrites + headers verified per #82's testing plan. Auth/API flows stay broken cross-origin until #83 — expected.
