### PR TITLE
Backfill dev Amplify app URL (issue #82)

### DIFF
--- a/infra/envs/dev/amplify.auto.tfvars
+++ b/infra/envs/dev/amplify.auto.tfvars
@@ -3,4 +3,4 @@
 # the Supabase URL/anon key are public by design (RLS is the boundary).
 vite_supabase_url      = "https://akceiidofsiajrjtgone.supabase.co" # cambree-staging project
 vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFrY2VpaWRvZnNpYWpyanRnb25lIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODUyODE2OTgsImV4cCI6MjEwMDg1NzY5OH0.IFyk54T-pg1uWCEp3E1BO-kDHTIQXjgH23qImLYBehU"
-vite_app_url           = "" # after first apply: the amplify_branch_url output
+vite_app_url           = "https://dev.d1gtnd67v2ws7a.amplifyapp.com"


### PR DESCRIPTION
Sets `vite_app_url` for dev to the now-known Amplify URL (`https://dev.d1gtnd67v2ws7a.amplifyapp.com`, app `d1gtnd67v2ws7a`, first build SUCCEED, headers + rewrites verified). Staging/prod get theirs as the module promotes through the branch flow.