### PR TITLE
Staging Amplify URL backfill promotion (issue #82)

### DIFF
--- a/infra/envs/staging/amplify.auto.tfvars
+++ b/infra/envs/staging/amplify.auto.tfvars
@@ -3,4 +3,4 @@
 # the Supabase URL/anon key are public by design (RLS is the boundary).
 vite_supabase_url      = "https://akceiidofsiajrjtgone.supabase.co" # cambree-staging project
 vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFrY2VpaWRvZnNpYWpyanRnb25lIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODUyODE2OTgsImV4cCI6MjEwMDg1NzY5OH0.IFyk54T-pg1uWCEp3E1BO-kDHTIQXjgH23qImLYBehU"
-vite_app_url           = "" # end-state https://staging.cambree.ai (live on Vercel today; set after the #84 domain flip). Until then: amplify_branch_url output
+vite_app_url           = "https://staging.d33ublf97u0bs6.amplifyapp.com" # interim; becomes https://staging.cambree.ai after the #84 domain flip


### PR DESCRIPTION
Promotes #94 (staging `vite_app_url` backfill) to staging. On merge the staging apply sets the branch env var; one release afterward bakes it into the bundle. Also the first webhook-triggered staging build — validates the Git-connection migration.