### PR TITLE
Prod Amplify URL backfill + #82 docs pass (issue #82)

### DIFF
--- a/docs/aws-migration-plan.md
+++ b/docs/aws-migration-plan.md
@@ -129,6 +129,16 @@ Deploy-role trust policies match `sub = repo:Cambree-AI@311088446/cambrian-playb
 
 `infra/envs/{dev,staging,prod}` each own their state bucket `cambree-<env>-terraform-state-<account-id>` (versioned, public-access-blocked, `use_lockfile`, key `env/terraform.tfstate`). Bootstrap procedure (one-time per env, done 2026-08-20): assume `OrganizationAccountAccessRole` into the account, `terraform init && apply` with the backend block commented (local state creates the bucket), uncomment the backend, `terraform init -migrate-state`, confirm two clean plans. Terraform is pinned to 1.10.x (`.tool-versions` and the workflow) — state written by a newer CLI would lock the pinned CI out.
 
+### Amplify Hosting (created 2026-08-26, issue #82 — `infra/modules/amplify`)
+
+| Env | App id | Default URL | Builds branch |
+|---|---|---|---|
+| dev | d1gtnd67v2ws7a | https://dev.d1gtnd67v2ws7a.amplifyapp.com | `dev` |
+| staging | d33ublf97u0bs6 | https://staging.d33ublf97u0bs6.amplifyapp.com | `staging` (→ staging.cambree.ai after #84) |
+| prod | d1fuoohbeo8gqk | https://main.d1fuoohbeo8gqk.amplifyapp.com | `main` (→ cambree.ai after the #85 cutover; Vercel serves production until then) |
+
+Security headers live in `customHttp.yml` (repo root); rewrites in the module's `custom_rule`s. Git connection = Amplify GitHub App (org-installed) + `AMPLIFY_GITHUB_TOKEN` PAT at create time, followed by the console "Update required" connection migration per app. Ops notes: API-created branches never auto-run a first build (trigger one release); branch env-var changes don't rebuild (trigger a release to bake them).
+
 - **Modules (proposed):** `network` (VPC, subnets, endpoints), `ecr`, `ecs-worker` (cluster, task defs, autoscaling), `queue` (SQS + DLQ), `orchestration` (Step Functions, IAM roles), `api` (API Gateway REST + WebSocket APIs, Lambdas, DynamoDB connections table), `crons` (EventBridge Scheduler), `secrets` (Secrets Manager/SSM), `amplify` (the Amplify app, branch config, domain, headers/rewrites), `dns` (Route 53, ACM), `observability` (CloudWatch dashboards/alarms, log groups, cost alarms).
 - Amplify itself is created via Terraform (`aws_amplify_app`, `aws_amplify_branch`, `aws_amplify_domain_association`) so hosting config is code, not console.
 - Bedrock access (model-invocation IAM policies, inference profiles) is Terraform-managed.

--- a/infra/envs/prod/amplify.auto.tfvars
+++ b/infra/envs/prod/amplify.auto.tfvars
@@ -3,4 +3,4 @@
 # the Supabase URL/anon key are public by design (RLS is the boundary).
 vite_supabase_url      = "https://xtnidawfuaxwwwcnkewu.supabase.co" # Cambrian Playbook project (live production data)
 vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inh0bmlkYXdmdWF4d3d3Y25rZXd1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU3Njc2NzEsImV4cCI6MjA5MTM0MzY3MX0.JPTyCbsLk9Kr4AHo3ynszOo_SxvLA-XpT_5TzP8M71o"
-vite_app_url           = "" # keep the Vercel value (https://cambree.ai) - prod links must point at the live site until the #85 cutover
+vite_app_url           = "https://cambree.ai" # the live production site; stays correct through the #85 cutover

--- a/infra/modules/amplify/README.md
+++ b/infra/modules/amplify/README.md
@@ -36,3 +36,12 @@ the Supabase URL + anon key are designed to be public; **no server secret
 (`ANTHROPIC_API_KEY`, `SUPABASE_SERVICE_KEY`, ...) may ever be set here.**
 Fill the values in each env root's `amplify.auto.tfvars` from the Vercel
 project settings before merging.
+
+## Post-create console step (per app, once)
+
+Apps created via the PAT flow show **"Update required"** in the Amplify
+console: open the app and click through the Git-connection migration to the
+GitHub App (already installed org-wide). Until this is done, webhook builds
+may not trigger. Also: the first build never runs automatically for
+API-created branches (start one release), and branch env-var changes need a
+release to be baked into the bundle.


### PR DESCRIPTION
Closes out #82: sets prod `vite_app_url` to `https://cambree.ai`, records the three Amplify apps (dev `d1gtnd67v2ws7a`, staging `d33ublf97u0bs6`, prod `d1fuoohbeo8gqk`) in docs/aws-migration-plan.md §7 with the connection + ops notes, and documents the post-create console migration step in the module README. Prod env-var takes effect on promotion to main (approval-gated), then one release bakes it.