### PR TITLE
CORS + switchable API origin: Amplify SPA against Vercel APIs (issue #83)

### DIFF
--- a/api/_guard.js
+++ b/api/_guard.js
@@ -267,6 +267,36 @@ function isAllowedOrigin(origin) {
   if (h === "cambriancatalyst.ai" || h.endsWith(".cambriancatalyst.ai")) return true;
   if (h === "cambree.ai" || h.endsWith(".cambree.ai")) return true;
   if (h === "localhost" || h === "127.0.0.1") return true;
+  // Amplify default domains (issue #83) — exact per-app hostnames, never a
+  // wildcard on all of amplifyapp.com. App ids: docs/aws-migration-plan.md §7.
+  if (h === "dev.d1gtnd67v2ws7a.amplifyapp.com") return true;    // dev
+  if (h === "staging.d33ublf97u0bs6.amplifyapp.com") return true; // staging
+  if (h === "main.d1fuoohbeo8gqk.amplifyapp.com") return true;   // prod
+  return false;
+}
+
+// ── CORS (issue #83) ─────────────────────────────────────────────────────
+// The Amplify-hosted SPA calls these functions cross-origin. Auth is a
+// Bearer JWT (no cookies), so this is plain bearer-token CORS: echo the
+// origin back ONLY when allowlisted (never *), and answer preflight.
+// Returns true when the request was an OPTIONS preflight and has been
+// fully answered — the caller must return immediately in that case.
+export function applyCors(req, res) {
+  const origin = req.headers.origin || "";
+  if (origin && isAllowedOrigin(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Vary", "Origin");
+  }
+  if (req.method === "OPTIONS") {
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    res.setHeader(
+      "Access-Control-Allow-Headers",
+      "Authorization, Content-Type, X-Billable-Run, X-Billable-Max, X-Brief-Type, X-Seller-Url, X-Target-Company"
+    );
+    res.setHeader("Access-Control-Max-Age", "86400");
+    res.status(204).end();
+    return true;
+  }
   return false;
 }
 
@@ -374,6 +404,7 @@ export function buildAnthropicBody(body, { stream = false } = {}) {
 // ── MAIN GUARD ───────────────────────────────────────────────────────────
 // Returns sanitized body on success, null on rejection (response already sent).
 export async function guard(req, res, { stream = false } = {}) {
+  if (applyCors(req, res)) return null; // OPTIONS preflight answered
   if (req.method !== "POST") {
     res.status(405).end();
     return null;

--- a/api/admin.js
+++ b/api/admin.js
@@ -5,7 +5,7 @@
 
 export const config = { maxDuration: 120 };
 
-import { checkRateLimit, isAllowedOrigin, verifyJwt, decodeJwtPayload } from "./_guard.js";
+import { applyCors, checkRateLimit, isAllowedOrigin, verifyJwt, decodeJwtPayload } from "./_guard.js";
 
 const SB_URL = process.env.VITE_SUPABASE_URL;
 const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
@@ -28,6 +28,7 @@ async function sbFetch(path, maxRows = 10000) {
 import adminActionHandler, { isAdminEmail } from "./_admin-action.js";
 
 export default async function handler(req, res) {
+  if (applyCors(req, res)) return; // CORS preflight (issue #83)
   // Route POST requests to admin-action handler (consolidated to stay within Vercel 12-function limit)
   if (req.method === "POST") return adminActionHandler(req, res);
   if (req.method !== "GET") return res.status(405).end();

--- a/api/checkout.js
+++ b/api/checkout.js
@@ -8,7 +8,7 @@
 // promo code — never trusted from the client, since price IDs ship in the
 // bundle.
 
-import { verifyJwt, decodeJwtPayload, isAllowedOrigin, checkRateLimit } from "./_guard.js";
+import { applyCors, verifyJwt, decodeJwtPayload, isAllowedOrigin, checkRateLimit } from "./_guard.js";
 
 const STRIPE_SECRET = process.env.STRIPE_SECRET_KEY;
 const APP_URL = process.env.VITE_APP_URL || "https://www.cambriancatalyst.ai";
@@ -28,6 +28,7 @@ const PLAN_LIMITS = {
 const PROMO_PACK_RUNS = 20;
 
 export default async function handler(req, res) {
+  if (applyCors(req, res)) return; // CORS preflight (issue #83)
   if (req.method !== "POST") return res.status(405).end();
   if (!STRIPE_SECRET) return res.status(500).json({ error: "Stripe not configured" });
 

--- a/api/contact.js
+++ b/api/contact.js
@@ -3,7 +3,7 @@
 // Handles enterprise/invoice inquiry form submissions.
 // Logs the inquiry to the database and sends notification emails.
 
-import { isAllowedOrigin, checkRateLimit } from "./_guard.js";
+import { applyCors, isAllowedOrigin, checkRateLimit } from "./_guard.js";
 
 const SB_URL = process.env.VITE_SUPABASE_URL;
 const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
@@ -14,6 +14,7 @@ if (!ADMIN_EMAIL) console.warn("[contact] SUPERUSER_EMAIL not set — admin noti
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default async function handler(req, res) {
+  if (applyCors(req, res)) return; // CORS preflight (issue #83)
   if (req.method !== "POST") return res.status(405).end();
 
   const origin = req.headers.origin || req.headers.referer || "";

--- a/api/enrich-free.js
+++ b/api/enrich-free.js
@@ -6,6 +6,8 @@
 //
 // Priority: SEC EDGAR (authoritative for public cos) > Wikidata (notable cos) > null
 
+import { applyCors, isAllowedOrigin } from "./_guard.js";
+
 const UA = "Cambree info@cambree.ai";
 
 // ── In-memory cache (24hr TTL, max 500 entries) ──
@@ -177,21 +179,11 @@ async function wikidataLookup(company) {
   } catch { return null; }
 }
 
-// ── Origin check (replicates _guard.js logic) ──
-function isAllowedOrigin(origin) {
-  if (!origin) return process.env.VERCEL_ENV !== "production";
-  let u;
-  try { u = new URL(origin); } catch { return false; }
-  const h = u.hostname;
-  if (h === "cambriancatalyst.ai" || h === "www.cambriancatalyst.ai") return true;
-  if (h === "cambrian-playbook.vercel.app") return true;
-  if (/^cambrian-playbook[a-z0-9-]*\.vercel\.app$/.test(h)) return true;
-  if (h === "localhost" || h === "127.0.0.1") return true;
-  return false;
-}
-
 // ── Main handler ──
+// Origin check now shared with _guard.js (issue #83) — the local replica had
+// drifted (it never learned cambree.ai, silently 403ing in production).
 export default async function handler(req, res) {
+  if (applyCors(req, res)) return; // CORS preflight (issue #83)
   if (req.method !== "GET") return res.status(405).json({ error: "GET only" });
 
   // Origin check — block external callers

--- a/api/fetch.js
+++ b/api/fetch.js
@@ -19,7 +19,7 @@
 // Security model: HANDOFF_06 §2. All SSRF validation in api/_fetch-ssrf.js.
 // Redirect re-validation: each 3xx hop is SSRF-checked before following.
 
-import { verifyJwt, isAllowedOrigin } from './_guard.js';
+import { applyCors, verifyJwt, isAllowedOrigin } from './_guard.js';
 import { validateUrl } from './_fetch-ssrf.js';
 
 export const config = { maxDuration: 30 };
@@ -351,6 +351,7 @@ async function renderWithService(url) {
 
 // ── Main handler ──────────────────────────────────────────────────────────────
 export default async function handler(req, res) {
+  if (applyCors(req, res)) return; // CORS preflight (issue #83)
   // All failures → { ok: false, reason, url } — never a 500 that breaks the brief.
 
   if (req.method !== 'POST') return res.status(405).json({ ok: false, reason: 'fetch_failed' });

--- a/api/hubspot.js
+++ b/api/hubspot.js
@@ -7,7 +7,7 @@
 // GET  /api/hubspot?code=...&state=...  → OAuth callback
 // POST /api/hubspot { action: "start" | "status" | "disconnect" | "push_postcall" | "push_brief" }
 
-import { isAllowedOrigin, verifyJwt, decodeJwtPayload, checkRateLimit } from "./_guard.js";
+import { applyCors, isAllowedOrigin, verifyJwt, decodeJwtPayload, checkRateLimit } from "./_guard.js";
 import {
   isConfigured, buildAuthUrl, signState, verifyState,
   exchangeCodeForTokens, getPortalInfo, getOwnerByToken, saveTokenForUser,
@@ -233,6 +233,7 @@ async function pushExecutivesAsContacts(userId, { executives, companyName, compa
 // ── Main handler ───────────────────────────────────────────────────────
 
 export default async function handler(req, res) {
+  if (applyCors(req, res)) return; // CORS preflight (issue #83)
   // ── GET: OAuth callback from HubSpot ─────────────────────────────────
   // HubSpot redirects here with ?code=...&state=... after user approves.
   // Exchange code for tokens immediately and redirect back to the app.

--- a/api/invite.js
+++ b/api/invite.js
@@ -3,7 +3,7 @@
 // POST { email, role } with admin JWT → creates invitation row +
 // sends Supabase invite email with acceptance link.
 
-import { isAllowedOrigin, verifyJwt, decodeJwtPayload } from "./_guard.js";
+import { applyCors, isAllowedOrigin, verifyJwt, decodeJwtPayload } from "./_guard.js";
 
 const SB_URL = process.env.VITE_SUPABASE_URL;
 const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
@@ -39,6 +39,7 @@ async function sbFetch(path, method = "GET", body = null, token = SB_KEY) {
 }
 
 export default async function handler(req, res) {
+  if (applyCors(req, res)) return; // CORS preflight (issue #83)
   if (req.method !== "POST") return res.status(405).end();
   if (!SB_KEY) return res.status(500).json({ error: "Server not configured for invitations" });
 

--- a/api/knowledge.js
+++ b/api/knowledge.js
@@ -58,9 +58,10 @@ import { RFP_PROCUREMENT_INJECTION, RFP_SIGNAL_SCORING, RFP_SOURCE_TIERS, RFP_SE
 import { PRE_RFP_SIGNAL_INJECTION, PRE_RFP_INTENT_KEYWORDS, PRE_RFP_SCORING_RUBRIC } from "../src/data/preRfpSignalKnowledge.js";
 import { DISPLACEMENT_INJECTION, DISPLACEMENT_DISCOVERY } from "../src/data/displacementKnowledge.js";
 
-import { checkRateLimit, isAllowedOrigin, checkGuestLimit, incrementGuestUsage, verifyJwt } from "./_guard.js";
+import { applyCors, checkRateLimit, isAllowedOrigin, checkGuestLimit, incrementGuestUsage, verifyJwt } from "./_guard.js";
 
 export default async function handler(req, res) {
+  if (applyCors(req, res)) return; // CORS preflight (issue #83)
   if (req.method !== "GET") { res.status(405).end(); return; }
 
   // Origin check — only allow requests from known domains

--- a/api/meter-run.js
+++ b/api/meter-run.js
@@ -25,7 +25,7 @@
 // checks the org's allowance, increments, and answers. That is the whole job —
 // which is exactly why it is reliable.
 
-import { isAllowedOrigin, checkRateLimit, verifyJwt, decodeJwtPayload } from "./_guard.js";
+import { applyCors, isAllowedOrigin, checkRateLimit, verifyJwt, decodeJwtPayload } from "./_guard.js";
 import { checkOrgUsage, incrementUsage, incrementMaxUsage } from "./_usage.js";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -38,6 +38,7 @@ const KINDS = {
 };
 
 export default async function handler(req, res) {
+  if (applyCors(req, res)) return; // CORS preflight (issue #83)
   if (req.method !== "POST") return res.status(405).end();
 
   const origin = req.headers.origin || req.headers.referer || "";

--- a/api/referral.js
+++ b/api/referral.js
@@ -4,7 +4,7 @@
 // first brief completion. Awards +1 run to the referrer's org (capped
 // at 5 bonus runs per month).
 
-import { verifyJwt, decodeJwtPayload, isAllowedOrigin, checkRateLimit } from "./_guard.js";
+import { applyCors, verifyJwt, decodeJwtPayload, isAllowedOrigin, checkRateLimit } from "./_guard.js";
 
 const SB_URL = process.env.VITE_SUPABASE_URL;
 const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
@@ -27,6 +27,7 @@ async function sbRpc(fn, params) {
 }
 
 export default async function handler(req, res) {
+  if (applyCors(req, res)) return; // CORS preflight (issue #83)
   if (req.method !== "POST") return res.status(405).end();
 
   const origin = req.headers.origin || req.headers.referer || "";

--- a/api/request-access.js
+++ b/api/request-access.js
@@ -9,7 +9,7 @@
 // Does NOT create any auth account directly — signup happens via the emailed
 // invite link.
 
-import { isAllowedOrigin, checkRateLimit } from "./_guard.js";
+import { applyCors, isAllowedOrigin, checkRateLimit } from "./_guard.js";
 import { provisionTrialAccess } from "./_provision.js";
 
 const SB_URL = process.env.VITE_SUPABASE_URL;
@@ -120,6 +120,7 @@ async function notifyRequester({ name, email }) {
 }
 
 export default async function handler(req, res) {
+  if (applyCors(req, res)) return; // CORS preflight (issue #83)
   if (req.method !== "POST") return res.status(405).end();
 
   const origin = req.headers.origin || req.headers.referer || "";

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -1,7 +1,9 @@
-# Amplify Hosting custom headers (issue #82) - ported byte-for-byte from the
-# "headers" block in vercel.json; keep the two in sync while both hosts serve
-# the SPA. The CSP connect-src additions for calling the Vercel API
-# cross-origin land with issue #83.
+# Amplify Hosting custom headers (issue #82) - ported from the "headers"
+# block in vercel.json; keep the two in sync while both hosts serve the SPA.
+# Deviation from vercel.json (issue #83): connect-src additionally allows the
+# Vercel API origins (staging.cambree.ai, www.cambree.ai, cambree.ai) so the
+# Amplify-hosted SPA can call the functions cross-origin until they move to
+# AWS (#86-#89).
 customHeaders:
   - pattern: '**'
     headers:
@@ -18,4 +20,4 @@ customHeaders:
       - key: Permissions-Policy
         value: 'camera=(), microphone=(), geolocation=()'
       - key: Content-Security-Policy
-        value: "default-src 'self'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://api.anthropic.com https://api.hubapi.com https://vercel.live; img-src 'self' data: https:; worker-src 'self' blob:; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+        value: "default-src 'self'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://api.anthropic.com https://api.hubapi.com https://vercel.live https://staging.cambree.ai https://www.cambree.ai https://cambree.ai; img-src 'self' data: https:; worker-src 'self' blob:; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"

--- a/infra/envs/dev/amplify.auto.tfvars
+++ b/infra/envs/dev/amplify.auto.tfvars
@@ -4,3 +4,4 @@
 vite_supabase_url      = "https://akceiidofsiajrjtgone.supabase.co" # cambree-staging project
 vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFrY2VpaWRvZnNpYWpyanRnb25lIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODUyODE2OTgsImV4cCI6MjEwMDg1NzY5OH0.IFyk54T-pg1uWCEp3E1BO-kDHTIQXjgH23qImLYBehU"
 vite_app_url           = "https://dev.d1gtnd67v2ws7a.amplifyapp.com"
+vite_api_url           = "https://staging.cambree.ai" # Vercel staging serves /api there

--- a/infra/envs/dev/amplify.tf
+++ b/infra/envs/dev/amplify.tf
@@ -25,6 +25,12 @@ variable "vite_app_url" {
   default     = ""
 }
 
+variable "vite_api_url" {
+  description = "Origin the SPA calls for /api/* (issue #83). Empty = same-origin relative paths."
+  type        = string
+  default     = ""
+}
+
 module "amplify" {
   source = "../../modules/amplify"
 
@@ -37,6 +43,7 @@ module "amplify" {
     VITE_SUPABASE_URL      = var.vite_supabase_url
     VITE_SUPABASE_ANON_KEY = var.vite_supabase_anon_key
     VITE_APP_URL           = var.vite_app_url
+    VITE_API_URL           = var.vite_api_url
   }
 }
 

--- a/infra/envs/prod/amplify.auto.tfvars
+++ b/infra/envs/prod/amplify.auto.tfvars
@@ -4,3 +4,4 @@
 vite_supabase_url      = "https://xtnidawfuaxwwwcnkewu.supabase.co" # Cambrian Playbook project (live production data)
 vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inh0bmlkYXdmdWF4d3d3Y25rZXd1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU3Njc2NzEsImV4cCI6MjA5MTM0MzY3MX0.JPTyCbsLk9Kr4AHo3ynszOo_SxvLA-XpT_5TzP8M71o"
 vite_app_url           = "https://cambree.ai" # the live production site; stays correct through the #85 cutover
+vite_api_url           = "https://www.cambree.ai" # Vercel prod /api; MUST switch before the #85 cutover (the vercel.app alias 307s to this domain today, unusable for CORS)

--- a/infra/envs/prod/amplify.tf
+++ b/infra/envs/prod/amplify.tf
@@ -25,6 +25,12 @@ variable "vite_app_url" {
   default     = ""
 }
 
+variable "vite_api_url" {
+  description = "Origin the SPA calls for /api/* (issue #83). Empty = same-origin relative paths."
+  type        = string
+  default     = ""
+}
+
 module "amplify" {
   source = "../../modules/amplify"
 
@@ -37,6 +43,7 @@ module "amplify" {
     VITE_SUPABASE_URL      = var.vite_supabase_url
     VITE_SUPABASE_ANON_KEY = var.vite_supabase_anon_key
     VITE_APP_URL           = var.vite_app_url
+    VITE_API_URL           = var.vite_api_url
   }
 }
 

--- a/infra/envs/staging/amplify.auto.tfvars
+++ b/infra/envs/staging/amplify.auto.tfvars
@@ -4,3 +4,4 @@
 vite_supabase_url      = "https://akceiidofsiajrjtgone.supabase.co" # cambree-staging project
 vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFrY2VpaWRvZnNpYWpyanRnb25lIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODUyODE2OTgsImV4cCI6MjEwMDg1NzY5OH0.IFyk54T-pg1uWCEp3E1BO-kDHTIQXjgH23qImLYBehU"
 vite_app_url           = "https://staging.d33ublf97u0bs6.amplifyapp.com" # interim; becomes https://staging.cambree.ai after the #84 domain flip
+vite_api_url           = "https://staging.cambree.ai" # Vercel staging serves /api there

--- a/infra/envs/staging/amplify.tf
+++ b/infra/envs/staging/amplify.tf
@@ -25,6 +25,12 @@ variable "vite_app_url" {
   default     = ""
 }
 
+variable "vite_api_url" {
+  description = "Origin the SPA calls for /api/* (issue #83). Empty = same-origin relative paths."
+  type        = string
+  default     = ""
+}
+
 module "amplify" {
   source = "../../modules/amplify"
 
@@ -37,6 +43,7 @@ module "amplify" {
     VITE_SUPABASE_URL      = var.vite_supabase_url
     VITE_SUPABASE_ANON_KEY = var.vite_supabase_anon_key
     VITE_APP_URL           = var.vite_app_url
+    VITE_API_URL           = var.vite_api_url
   }
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
+import { apiFetch } from "./lib/api.js";
 import { OUTCOMES } from "./data/outcomes.js";
 import { RIVER_STAGES } from "./data/riverFramework.js";
 import { SAMPLE_ROWS } from "./data/sampleAccounts.js";
@@ -162,7 +163,7 @@ let KL_DISPLACEMENT_DISCOVERY = ""; // Displacement discovery questions
 
 async function fetchKnowledgeLayer() {
   try {
-    const r = await fetch("/api/knowledge", { headers: authHeaders() });
+    const r = await apiFetch("/api/knowledge", { headers: authHeaders() });
     if (!r.ok) return;
     const d = await r.json();
     KL_NEGOTIATIONS = d.negotiations || "";
@@ -1131,7 +1132,7 @@ async function claudeFetch(body, { retries = 3, extraHeaders = {} } = {}) {
   const sleep = ms => new Promise(r => setTimeout(r, ms));
   for (let attempt = 0; attempt < retries; attempt++) {
     try {
-      const r = await fetch("/api/claude", {
+      const r = await apiFetch("/api/claude", {
         method: "POST",
         headers: { ...authHeaders(), ..._trackingCtx, ...extraHeaders },
         body: JSON.stringify(body),
@@ -1222,7 +1223,7 @@ async function streamAI(prompt, onChunk, maxTok=2000, { model = null, signal = n
   for (let attempt = 0; attempt < 3; attempt++) {
     if (signal?.aborted) return null;
     try {
-      response = await fetch('/api/claude-stream', {
+      response = await apiFetch('/api/claude-stream', {
         method: 'POST',
         signal: signal || undefined,
         headers: { ...authHeaders(), ..._trackingCtx },
@@ -1316,7 +1317,7 @@ async function streamAIWithSearch(prompt, onChunk, maxTok=2000, { maxSearches=1,
   for (let attempt = 0; attempt < 3; attempt++) {
     if (signal?.aborted) return null;
     try {
-      response = await fetch('/api/claude-stream', {
+      response = await apiFetch('/api/claude-stream', {
         method: 'POST',
         signal: signal || undefined,
         headers: { ...authHeaders(), ..._trackingCtx, ...extraHeaders },
@@ -2333,7 +2334,7 @@ async function runExecIntelPipeline({ co, url, member, sellerUrl, products, sell
 
       for (const _leadershipUrl of _candidateUrls) {
         try {
-          const _fr = await fetch("/api/fetch", {
+          const _fr = await apiFetch("/api/fetch", {
             method: "POST",
             headers: authHeaders(),
             body: JSON.stringify({ url: _leadershipUrl, render: "auto" }),
@@ -4402,7 +4403,7 @@ function PasswordGate({ onAuth }) {
         if(!first||!last||!email||!company){setErr("Please fill in every field.");setLoading(false);return;}
         if(!EMAIL_RE.test(email)){setErr("Please enter a valid work email.");setLoading(false);return;}
         reqInFlightRef.current=true;
-        const r=await fetch("/api/request-access",{
+        const r=await apiFetch("/api/request-access",{
           method:"POST",
           headers:{"Content-Type":"application/json"},
           body:JSON.stringify({name:(first+" "+last).trim(),email,company,...(promoCode.trim()?{promoCode:promoCode.trim()}:{})}),
@@ -5685,7 +5686,7 @@ export default function App(){
     if(hubspotStatus!==null||hubspotCheckedRef.current||!sbToken) return;
     hubspotCheckedRef.current=true;
     console.log("[hubspot] Checking status...");
-    fetch("/api/hubspot",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${sbToken}`},body:JSON.stringify({action:"status"})})
+    apiFetch("/api/hubspot",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${sbToken}`},body:JSON.stringify({action:"status"})})
       .then(r=>{
         console.log("[hubspot] Status response:", r.status, r.statusText);
         return r.ok?r.json():r.text().then(t=>{console.warn("[hubspot] Status error body:",t);return null;});
@@ -5944,7 +5945,7 @@ export default function App(){
       const base64 = btoa(new Uint8Array(arrayBuffer).reduce((s, b) => s + String.fromCharCode(b), ""));
       const mimeType = file.type || (file.name.endsWith(".png") ? "image/png" : "image/jpeg");
 
-      const r = await fetch("/api/claude", {
+      const r = await apiFetch("/api/claude", {
         method: "POST",
         headers: authHeaders(),
         body: JSON.stringify({
@@ -8135,7 +8136,7 @@ Return ONLY raw JSON:
       return false;
     };
     try {
-      const r = await fetch("/api/meter-run", {
+      const r = await apiFetch("/api/meter-run", {
         method: "POST",
         headers: { ...authHeaders(), "Content-Type": "application/json" },
         body: JSON.stringify({ kind }),
@@ -9750,7 +9751,7 @@ Return ONLY raw JSON:
     try {
       const freeResults = await Promise.all(members.map(async m => {
         try {
-          const r = await fetch(`/api/enrich-free?company=${encodeURIComponent(m.company)}&domain=${encodeURIComponent(m.company_url || "")}`);
+          const r = await apiFetch(`/api/enrich-free?company=${encodeURIComponent(m.company)}&domain=${encodeURIComponent(m.company_url || "")}`);
           if (!r.ok) return [m.company, null];
           const d = await r.json();
           return [m.company, d.organization || null];
@@ -10604,7 +10605,7 @@ Return ONLY raw JSON:
     refreshOrgCtx();
     // Process referral reward on first brief completion
     if (sbToken) {
-      fetch("/api/referral", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+      apiFetch("/api/referral", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
         body: JSON.stringify({ action: "process_reward" }) })
         .then(r => r.json()).then(d => { if (d.rewarded) { refreshOrgCtx(); setChatMessages(prev => [...prev, { role: "assistant", content: "Nice — your referral just earned the person who invited you a bonus run. Pay it forward: share your own referral link from the My Company panel." }]); } })
         .catch(() => {});
@@ -12470,7 +12471,7 @@ Return ONLY raw JSON:
     console.log(`[hubspot] Pushing ${action}:`, JSON.stringify({company: data?.company?.name, domain: data?.company?.domain, selectedAccount: selectedAccount?.company}, null, 2));
     setHubspotPushing(action);
     try{
-      const r=await fetch("/api/hubspot",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${sbToken}`},body:JSON.stringify({action,data})});
+      const r=await apiFetch("/api/hubspot",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${sbToken}`},body:JSON.stringify({action,data})});
       const d=await r.json();
       if(d.ok){
         const parts=[];
@@ -12535,7 +12536,7 @@ Return ONLY raw JSON:
         const fitReason = fit?.reason ?? "";
         const ownership = fit?.ownership || m.publicPrivate || "";
         try {
-          const r = await fetch("/api/hubspot",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${sbToken}`},body:JSON.stringify({
+          const r = await apiFetch("/api/hubspot",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${sbToken}`},body:JSON.stringify({
             action: "push_brief",
             data: {
               company: { name: m.company, domain: m.company_url || "", industry: m.ind || "", employees: m.employees || "" },
@@ -13560,7 +13561,7 @@ Return ONLY raw JSON:
   if(!authed) return <PasswordGate onAuth={async(u,tok)=>{
     setAuthed(true);setSbUser(u);setSbToken(tok);setAuthToken(tok);fetchKnowledgeLayer();
     // Check HubSpot connection status
-    fetch("/api/hubspot",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${tok}`},body:JSON.stringify({action:"status"})})
+    apiFetch("/api/hubspot",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${tok}`},body:JSON.stringify({action:"status"})})
       .then(r=>{console.log("[hubspot] Login status check:",r.status);return r.json();})
       .then(d=>{console.log("[hubspot] Login status result:",JSON.stringify(d));setHubspotStatus(d);})
       .catch(e=>console.error("[hubspot] Login status failed:",e.message));
@@ -13582,7 +13583,7 @@ Return ONLY raw JSON:
     // Process pending referral code
     const pendingRef = sessionStorage.getItem("pending_referral_code");
     if (pendingRef && tok) {
-      fetch("/api/referral", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${tok}` },
+      apiFetch("/api/referral", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${tok}` },
         body: JSON.stringify({ action: "set_referrer", referralCode: pendingRef }) })
         .then(r => r.json()).then(d => { if (d.ok) sessionStorage.removeItem("pending_referral_code"); })
         .catch(() => {});
@@ -20039,7 +20040,7 @@ Return ONLY raw JSON:
                   ))}
                   <button onClick={async()=>{
                     try{
-                      const r=await fetch("/api/checkout",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${sbToken}`},body:JSON.stringify({planId:"promo_pack"})});
+                      const r=await apiFetch("/api/checkout",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${sbToken}`},body:JSON.stringify({planId:"promo_pack"})});
                       const d=await r.json();
                       if(d.url)window.location.href=d.url;
                       else alert(d.error||"Checkout failed — please try again.");
@@ -20068,7 +20069,7 @@ Return ONLY raw JSON:
                   <button onClick={async()=>{
                     if(!sbUser){setUpgradeOpen(false);setAuthed(false);return;}
                     try{
-                      const r=await fetch("/api/checkout",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${sbToken}`},body:JSON.stringify({priceId:plan.priceId,planId:plan.id})});
+                      const r=await apiFetch("/api/checkout",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${sbToken}`},body:JSON.stringify({priceId:plan.priceId,planId:plan.id})});
                       const d=await r.json();
                       if(d.url)window.location.href=d.url;
                       else alert(d.error||"Checkout failed — please try again.");
@@ -20156,7 +20157,7 @@ Return ONLY raw JSON:
                       const message=document.getElementById("cf-message")?.value?.trim();
                       if(!name||!email||!company){alert("Please fill in name, email, and company.");return;}
                       try{
-                        const r=await fetch("/api/contact",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({name,email,company,interest,message})});
+                        const r=await apiFetch("/api/contact",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({name,email,company,interest,message})});
                         const d=await r.json();
                         if(d.ok){setContactFormMsg(d.message);}
                         else{alert(d.error||"Failed to submit");}

--- a/src/components/OrgPanel.jsx
+++ b/src/components/OrgPanel.jsx
@@ -5,6 +5,7 @@
 // No-org users see a simplified account panel with "Create Organization".
 
 import React, { useState, useEffect } from "react";
+import { apiFetch } from "../lib/api.js";
 import { fetchOrgMembers, fetchOrgInvitations, sbPatch } from "../lib/org.js";
 import { timeAgo } from "../lib/utils.js";
 
@@ -15,7 +16,7 @@ function ReferralWidget({ sbToken }) {
   const [copied, setCopied] = useState(false);
   useEffect(() => {
     if (!sbToken) return;
-    fetch("/api/referral", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+    apiFetch("/api/referral", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
       body: JSON.stringify({ action: "get_referral_info" }) })
       .then(r => r.json()).then(d => { if (d.ok) setInfo(d); }).catch(() => {});
   }, [sbToken]);
@@ -45,14 +46,14 @@ function HubSpotSection({ sbToken }) {
 
   useEffect(() => {
     if (!sbToken) return;
-    fetch("/api/hubspot", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+    apiFetch("/api/hubspot", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
       body: JSON.stringify({ action: "status" }) })
       .then(r => r.json()).then(setStatus).catch(() => setStatus({ connected: false }));
   }, [sbToken]);
 
   const startConnect = () => {
     setLoading(true);
-    fetch("/api/hubspot", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+    apiFetch("/api/hubspot", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
       body: JSON.stringify({ action: "start" }) })
       .then(r => r.json())
       .then(d => { if (d.url) window.location.href = d.url; else setLoading(false); })
@@ -62,7 +63,7 @@ function HubSpotSection({ sbToken }) {
   const disconnect = () => {
     if (!confirm("Disconnect HubSpot? You can reconnect anytime.")) return;
     setDisconnecting(true);
-    fetch("/api/hubspot", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+    apiFetch("/api/hubspot", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
       body: JSON.stringify({ action: "disconnect" }) })
       .then(() => setStatus({ connected: false }))
       .finally(() => setDisconnecting(false));
@@ -180,7 +181,7 @@ export default function OrgPanel({ orgCtx, setOrgCtx, sbUser, sbToken, onClose }
     if (!email || !isAdmin) return;
     setInviteLoading(true); setInviteMsg("");
     try {
-      const res = await fetch("/api/invite", {
+      const res = await apiFetch("/api/invite", {
         method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
         body: JSON.stringify({ email, role: inviteRole }),
       });
@@ -200,7 +201,7 @@ export default function OrgPanel({ orgCtx, setOrgCtx, sbUser, sbToken, onClose }
     if (!isAdmin) return;
     setInviteLoading(true);
     try {
-      const res = await fetch("/api/invite", {
+      const res = await apiFetch("/api/invite", {
         method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
         body: JSON.stringify({ email: inv.email, role: inv.role }),
       });
@@ -218,7 +219,7 @@ export default function OrgPanel({ orgCtx, setOrgCtx, sbUser, sbToken, onClose }
     try {
       const url = createOrgUrl.trim();
       const sellerUrl = url ? (url.startsWith("http") ? url : `https://${url}`) : null;
-      const res = await fetch("/api/admin", {
+      const res = await apiFetch("/api/admin", {
         method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
         body: JSON.stringify({ action: "create_org", email: sbUser?.email, orgData: { name: createOrgName.trim(), seller_url: sellerUrl, plan: "trial" } }),
       });

--- a/src/components/SuperAdmin.jsx
+++ b/src/components/SuperAdmin.jsx
@@ -2,6 +2,7 @@
 // Locked to superuser email only. Shows engagement metrics across all users.
 
 import React, { useState, useEffect, useRef } from "react";
+import { apiFetch } from "../lib/api.js";
 import { timeAgo } from "../lib/utils.js";
 
 // ── Sortable column header component ──
@@ -73,7 +74,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
   const fetchData = (showSpinner) => {
     if (showSpinner) setLoading(true);
     else setRefreshing(true);
-    fetch("/api/admin", {
+    apiFetch("/api/admin", {
       headers: { Authorization: `Bearer ${sbToken}` },
     })
       .then(r => r.json())
@@ -251,7 +252,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
     setRequestBusy(rq.id);
     setRemovedRequests(prev => [...prev, rq.id]); // optimistic removal
     try {
-      const r = await fetch("/api/admin", {
+      const r = await apiFetch("/api/admin", {
         method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
         body: JSON.stringify({ action, requestId: rq.id, email: rq.email, ...(reason ? { reason } : {}) }),
       });
@@ -1034,7 +1035,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                   const role = document.getElementById("sa-invite-role")?.value || "rep";
                   if (!email || !orgId) { setPlanSaveMsg("Email and org required"); setTimeout(() => setPlanSaveMsg(""), 3000); return; }
                   try {
-                    const r = await fetch("/api/invite", {
+                    const r = await apiFetch("/api/invite", {
                       method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
                       body: JSON.stringify({ email, role, orgId }),
                     });
@@ -1069,7 +1070,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                   {sortRows(filteredUsers, memberSortKey, memberSortDir, { dateKeys: { last_active: true, created_at: true } }).map(u => {
                     const adminAction = async (action, extra = {}) => {
                       try {
-                        const r = await fetch("/api/admin", {
+                        const r = await apiFetch("/api/admin", {
                           method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
                           body: JSON.stringify({ action, email: u.email, userId: u.id, ...extra }),
                         });
@@ -1080,7 +1081,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                     };
                     const patchUser = async (fields, msg) => {
                       try {
-                        const r = await fetch("/api/admin", {
+                        const r = await apiFetch("/api/admin", {
                           method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
                           body: JSON.stringify({ action: "update_user", userId: u.id, email: u.email, fields }),
                         });
@@ -1292,7 +1293,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                     const body = { name, plan, ...(limits[plan] || {}) };
                     if (url) body.seller_url = url.startsWith("http") ? url : `https://${url}`;
                     try {
-                      const r = await fetch("/api/admin", {
+                      const r = await apiFetch("/api/admin", {
                         method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
                         body: JSON.stringify({ action: "create_org", email: "org", orgData: body }),
                       });
@@ -1334,7 +1335,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                           const members = data.users.filter(u => u.org_id === o.id);
                           const patchOrg = async (fields, msg) => {
                             try {
-                              const r = await fetch("/api/admin", {
+                              const r = await apiFetch("/api/admin", {
                                 method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
                                 body: JSON.stringify({ action: "update_org", orgId: o.id, email: "org", fields }),
                               });
@@ -1410,7 +1411,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                                         : `Delete "${o.name}"?`;
                                       if (!window.confirm(msg)) return;
                                       try {
-                                        const r = await fetch("/api/admin", {
+                                        const r = await apiFetch("/api/admin", {
                                           method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
                                           body: JSON.stringify({ action: "delete_org", orgId: o.id, email: "org" }),
                                         });
@@ -1440,7 +1441,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                 const companyOrgList = (data.orgs || []).filter(o => o.seller_url || o.member_count > 1);
                 const patchOrgApi = async (orgId, fields, msg) => {
                   try {
-                    const r = await fetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+                    const r = await apiFetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
                       body: JSON.stringify({ action: "update_org", orgId, email: "org", fields }) });
                     const d = await r.json();
                     setPlanSaveMsg(d.ok ? msg : `Error: ${d.error}`);
@@ -1449,7 +1450,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                 };
                 const moveUserToOrg = async (userId, email, targetOrgId, targetOrgName) => {
                   try {
-                    const r = await fetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+                    const r = await apiFetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
                       body: JSON.stringify({ action: "update_user", userId, email, fields: { org_id: targetOrgId } }) });
                     const d = await r.json();
                     setPlanSaveMsg(d.ok ? `✓ Moved ${email} → ${targetOrgName}` : `Error: ${d.error}`);
@@ -1471,7 +1472,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                           let cleaned = 0;
                           for (const o of unused) {
                             try {
-                              const r = await fetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` }, body: JSON.stringify({ action: "delete_org", orgId: o.id, email: "cleanup" }) });
+                              const r = await apiFetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` }, body: JSON.stringify({ action: "delete_org", orgId: o.id, email: "cleanup" }) });
                               const d = await r.json();
                               if (d.ok) cleaned++;
                             } catch {}
@@ -1527,7 +1528,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                                   onClick={async () => {
                                     if (!window.confirm(`Delete "${o.name}"?${members.length > 0 ? ` ${members.length} member(s) will be unassigned.` : ""}`)) return;
                                     try {
-                                      const r = await fetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` }, body: JSON.stringify({ action: "delete_org", orgId: o.id, email: "org" }) });
+                                      const r = await apiFetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` }, body: JSON.stringify({ action: "delete_org", orgId: o.id, email: "org" }) });
                                       const d = await r.json();
                                       setPlanSaveMsg(d.ok ? `✓ Deleted ${o.name}` : `Error: ${d.error}`);
                                     } catch { setPlanSaveMsg("Failed"); }
@@ -2365,7 +2366,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
         <div className="admin-action-menu" style={{ position: "fixed", top: menuPos.top, right: menuPos.right, left: "auto", zIndex: 99999 }}
           onClick={e => e.stopPropagation()}>
           <button className="admin-action-item" onClick={() => {
-            fetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+            apiFetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
               body: JSON.stringify({ action: "reset_password", email: menuContext.email, userId: menuContext.userId }) })
               .then(r => r.json()).then(d => setPlanSaveMsg(d.ok ? d.message || "Password reset sent" : `Error: ${d.error}`))
               .catch(() => setPlanSaveMsg("Failed"));
@@ -2377,7 +2378,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
             if (!targetEmail || !targetEmail.includes("@")) { setOpenMenu(null); return; }
             const target = data.users?.find(tu => tu.email?.toLowerCase() === targetEmail.toLowerCase());
             if (target) {
-              fetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+              apiFetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
                 body: JSON.stringify({ action: "update_user", userId: target.id, email: target.email, fields: { org_id: menuContext.orgId, role: menuContext.role } }) })
                 .then(r => r.json()).then(d => { setPlanSaveMsg(d.ok ? `Cloned → ${targetEmail}` : `Error: ${d.error}`); setTimeout(fetchData, 500); })
                 .catch(() => setPlanSaveMsg("Clone failed"));
@@ -2392,7 +2393,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
             setOpenMenu(null);
           }}>Copy Invite Link</button>
           <button className="admin-action-item" onClick={() => {
-            fetch("/api/invite", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+            apiFetch("/api/invite", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
               body: JSON.stringify({ email: menuContext.email, role: menuContext.role }) })
               .then(r => r.json()).then(d => setPlanSaveMsg(d.ok ? (d.note || `Sent to ${menuContext.email}`) : `Error: ${d.error}`))
               .catch(() => setPlanSaveMsg("Failed"));
@@ -2403,7 +2404,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
             <button className="admin-action-item danger" onClick={async () => {
               if (!window.confirm(`Delete ${menuContext.email}? This removes their account permanently.`)) { setOpenMenu(null); return; }
               try {
-                const r = await fetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+                const r = await apiFetch("/api/admin", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
                   body: JSON.stringify({ action: "delete_user", userId: menuContext.userId, email: menuContext.email }) });
                 const d = await r.json();
                 setPlanSaveMsg(d.ok ? `Deleted ${menuContext.email}` : `Error: ${d.error}`);

--- a/src/components/UserDashboard.jsx
+++ b/src/components/UserDashboard.jsx
@@ -3,6 +3,7 @@
 // into a single two-column layout using admin-* CSS classes from App.css.
 
 import React, { useState, useEffect, useMemo } from "react";
+import { apiFetch } from "../lib/api.js";
 import { fetchOrgMembers, fetchOrgInvitations, sbPatch } from "../lib/org.js";
 import { timeAgo } from "../lib/utils.js";
 
@@ -28,14 +29,14 @@ function HubSpotSection({ sbToken, onStatusChange }) {
 
   useEffect(() => {
     if (!sbToken) return;
-    fetch("/api/hubspot", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+    apiFetch("/api/hubspot", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
       body: JSON.stringify({ action: "status" }) })
       .then(r => r.json()).then(s => { setStatus(s); onStatusChange?.(s); }).catch(() => setStatus({ connected: false }));
   }, [sbToken]);
 
   const startConnect = () => {
     setLoading(true);
-    fetch("/api/hubspot", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+    apiFetch("/api/hubspot", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
       body: JSON.stringify({ action: "start" }) })
       .then(r => r.json())
       .then(d => { if (d.url) window.location.href = d.url; else setLoading(false); })
@@ -45,7 +46,7 @@ function HubSpotSection({ sbToken, onStatusChange }) {
   const disconnect = () => {
     if (!confirm("Disconnect HubSpot? You can reconnect anytime.")) return;
     setDisconnecting(true);
-    fetch("/api/hubspot", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+    apiFetch("/api/hubspot", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
       body: JSON.stringify({ action: "disconnect" }) })
       .then(() => { setStatus({ connected: false }); onStatusChange?.({ connected: false }); })
       .finally(() => setDisconnecting(false));
@@ -89,7 +90,7 @@ function ReferralWidget({ sbToken }) {
   const [copied, setCopied] = useState(false);
   useEffect(() => {
     if (!sbToken) return;
-    fetch("/api/referral", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+    apiFetch("/api/referral", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
       body: JSON.stringify({ action: "get_referral_info" }) })
       .then(r => r.json()).then(d => { if (d.ok) setInfo(d); }).catch(() => {});
   }, [sbToken]);
@@ -273,7 +274,7 @@ export default function UserDashboard({ orgCtx, setOrgCtx, sbUser, sbToken, save
     setInviteLoading(true);
     if (!emailOverride) setInviteMsg("");
     try {
-      const res = await fetch("/api/invite", {
+      const res = await apiFetch("/api/invite", {
         method: "POST",
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
         body: JSON.stringify({ email: email.toLowerCase(), role: inviteRole }),
@@ -341,7 +342,7 @@ export default function UserDashboard({ orgCtx, setOrgCtx, sbUser, sbToken, save
     if (!isAdmin) return;
     setInviteLoading(true);
     try {
-      const res = await fetch("/api/invite", {
+      const res = await apiFetch("/api/invite", {
         method: "POST",
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
         body: JSON.stringify({ email: inv.email, role: inv.role }),

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,12 +1,21 @@
 // lib/api.js — Anthropic API wrapper
 // All Claude calls go through /api/claude serverless proxy
 
+// API origin (issue #83). Unset/empty => relative paths (same-origin), so
+// Vercel-served deploys are byte-identical in behavior. Amplify builds set
+// VITE_API_URL to the Vercel API origin until the functions migrate to AWS.
+export const API_BASE = import.meta.env.VITE_API_URL || "";
+
+// Every client call to /api/* goes through this so the origin is switchable
+// per deployment (and later per endpoint, when functions move to AWS).
+export const apiFetch = (path, opts) => fetch(API_BASE + path, opts);
+
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 export async function callAI(prompt, maxTok=1000){
   for(let attempt=0; attempt<3; attempt++){
     try{
-      const r = await fetch("/api/claude",{
+      const r = await apiFetch("/api/claude",{
         method:"POST",
         headers:{"Content-Type":"application/json"},
         body:JSON.stringify({
@@ -105,7 +114,7 @@ export async function callAI(prompt, maxTok=1000){
 // ── GENERATE BRIEF ────────────────────────────────────────────────────────────
 
 export async function callAIRaw(payload) {
-  const r = await fetch("/api/claude", {
+  const r = await apiFetch("/api/claude", {
     method: "POST",
     headers: {"Content-Type": "application/json"},
     body: JSON.stringify(payload),
@@ -114,7 +123,7 @@ export async function callAIRaw(payload) {
 }
 
 export async function streamAI(prompt, onChunk, maxTok=2000) {
-  const response = await fetch('/api/claude-stream', {
+  const response = await apiFetch('/api/claude-stream', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({


### PR DESCRIPTION
Implements #83 — the Amplify-hosted SPAs can call the Vercel functions cross-origin; Vercel-served deploys are behaviorally unchanged (`VITE_API_URL` unset ⇒ relative paths).

**Server** (`api/`): `applyCors` in `_guard.js` — OPTIONS preflight + `Access-Control-Allow-Origin` echoed only for allowlisted origins (never `*`), `Vary: Origin`; wired into `guard()` and all 11 browser-facing handlers. Allowlist gains the three exact Amplify default domains (no amplifyapp.com wildcard). **Bugfix bycatch**: `enrich-free.js`'s drifted local origin-check never learned `cambree.ai` and has been silently 403ing in production since the rebrand — now uses the shared check.

**Client** (`src/`): `apiFetch`/`API_BASE` in `lib/api.js`; all 50 `/api/*` call sites (App.jsx, SuperAdmin, OrgPanel, UserDashboard, api.js) route through it. Grep gate: zero raw `fetch("/api/` remain. ESLint problem count identical to baseline (135, all pre-existing); `vite build` green.

**Infra**: `VITE_API_URL` per env (dev/staging → `https://staging.cambree.ai`; prod → `https://www.cambree.ai`, must switch before the #85 cutover — the vercel.app alias 307s to the custom domain, and redirects break preflights). Amplify CSP `connect-src` gains the API origins.

**Testing after the dev merge** (needs both the Vercel deploy of the CORS change and the Amplify rebuild): full flow from https://dev.d1gtnd67v2ws7a.amplifyapp.com — sign-in, ICP, brief with SSE streaming; negative preflight from a disallowed origin; same-origin regression on Vercel staging.