### PR TITLE
fix: save silently fails after initial session creation (F-019 / #108)

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -157,5 +157,10 @@ export async function sbSessions(method, path, token, body) {
     body: body ? JSON.stringify(body) : undefined,
   });
   const t = await r.text();
-  return t ? JSON.parse(t) : null;
+  const parsed = t ? JSON.parse(t) : null;
+  if (!r.ok) throw Object.assign(
+    new Error(parsed?.message || parsed?.error || `Supabase ${method} failed: ${r.status}`),
+    { status: r.status, code: parsed?.code }
+  );
+  return parsed;
 }


### PR DESCRIPTION
## Summary

- `sbSessions()` in `src/lib/supabase.js` now throws on non-2xx responses instead of returning the error JSON silently
- The `saveSession` try/catch was already wired to show a save-error state — it just never fired because no exception was ever raised
- One-line change; zero risk to successful paths (2xx responses are unchanged)

## Root cause

`sbSessions` parsed the Supabase response body and returned it regardless of HTTP status. A failed PATCH (e.g. RLS reject, expired token, network hiccup) returned the error JSON as a plain object. The `saveSession` handler awaited the result without inspecting it, then unconditionally called `setSaveStatus('saved')`.

Evidence: session row `updated_at` stayed at 21:14:23 UTC across five Save clicks spanning 45 minutes of a live run.

## Test plan

- Save a session → confirm `sessions.updated_at` advances in Supabase
- Revoke auth token and save → confirm UI shows error state instead of "Saved"
- Initial session creation (POST) → unaffected; still sets `currentSessionId`

Fixes #108