### PR TITLE
fix: ICP build shows error card instead of empty state on stream failure (#111)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8482,6 +8482,19 @@ Return ONLY raw JSON:
         }
         if (err?.type === "unavailable" || err?.type === "overloaded_error") {
           setSellerICP(prev => prev || ({ _error: "Our AI engine is temporarily overloaded. Click Regenerate ICP in a moment to retry." }));
+        } else {
+          // No recognised error type (null return, parse failure, network drop).
+          // Preserve any partial data that streamed in; only fall back to the error
+          // card if nothing was captured — prevents the empty-state "Build ICP Now"
+          // flash that occurs when the stream fails before partial JSON lands.
+          setSellerICP(prev => {
+            if (prev && (prev.sellerName || prev.icp)) {
+              // Partial data present — strip _loading so the partial ICP renders.
+              const { _loading, ...rest } = prev;
+              return { ...rest, _warning: "ICP build returned partial results. Click Regenerate to complete it." };
+            }
+            return prev || { _error: "ICP build failed — our AI engine may be temporarily busy. Click Regenerate ICP to retry." };
+          });
         }
         setIcpLoading(false); setIcpStatus(""); return;
       }


### PR DESCRIPTION
## Summary

- When the Sonnet ICP Pass 2 returns `null` with no recognised error object, the error handler now always calls `setSellerICP` before exiting — so users see an "ICP build failed — Regenerate" card instead of "Build ICP Now"
- Secondary: if partial data streamed in before the failure, it is preserved (with `_loading` stripped) so the partial ICP renders with a warning, giving the user something to work with

## Root cause

The `if (!raw || ...)` block in `buildSellerICP` had three outcomes:
1. `usage_limit_exceeded` → set error state + return ✓
2. `unavailable / overloaded_error` → set error state + fall through to return ✓
3. **Everything else (null return, parse failure, network drop) → no `setSellerICP` call → empty state** ✗

The `else` branch added here closes case 3.

## Reproducing before the fix

Build an ICP for a very new / low-indexed domain where the Sonnet model returns empty or non-JSON output. The build shows the skeleton loading card, then jumps to the "Build ICP Now" empty state with no Regenerate button.

## Test plan

- Run an ICP build for a real domain → should complete normally (no regression)
- To trigger the fix path: disconnect network mid-build and reconnect → should show "ICP build failed — Regenerate ICP" red card instead of "Build ICP Now"

Fixes #111