### PR TITLE
fix: ICP build observable failures, no dead states, preserve what the user saw (#111)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15471,8 +15471,8 @@ Return ONLY raw JSON:
                           </span>
                         )}
                         {sellerICP?._warning && (
-                          <div style={{marginTop:6,fontSize:11,color:"var(--amber)",fontWeight:600}}>
-                            {sellerICP._warning}
+                          <div style={{marginTop:8,fontSize:12,color:"var(--amber)",fontWeight:700,background:"var(--amber-bg)",border:"1px solid var(--amber)",borderRadius:8,padding:"8px 12px"}}>
+                            ⚠ {sellerICP._warning}
                           </div>
                         )}
                       </>
@@ -15571,6 +15571,14 @@ Return ONLY raw JSON:
 
             {sellerICP?._error&&!sellerICP?.icp&&(
               <div style={{maxWidth:520,margin:"40px auto",textAlign:"center"}}>
+                {(icpPreview?.sellerDescription || icpPreview?.marketCategory || (icpPreview?.differentiators||[]).length>0) && (
+                  <div style={{textAlign:"left",background:"var(--bg-1)",border:"1px solid var(--line-0)",borderRadius:"var(--r-md)",padding:"14px 16px",marginBottom:14}}>
+                    <div style={{fontSize:10,fontWeight:700,letterSpacing:.6,color:"var(--ink-3)",marginBottom:8}}>WHAT WE FOUND BEFORE THE BUILD FAILED — NOT SAVED, NOT USED FOR SCORING</div>
+                    {icpPreview?.sellerDescription && <div style={{fontSize:13,color:"var(--ink-1)",lineHeight:1.6,marginBottom:8}}>{icpPreview.sellerDescription}</div>}
+                    {icpPreview?.marketCategory && <div style={{fontSize:12,color:"var(--ink-2)",marginBottom:8}}>{icpPreview.marketCategory}</div>}
+                    {(icpPreview?.differentiators||[]).length>0 && <div style={{display:"flex",flexWrap:"wrap",gap:6}}>{icpPreview.differentiators.map((d,i)=><span key={i} style={{background:"var(--green-bg)",border:"1px solid #2E6B2E44",borderRadius:20,padding:"3px 10px",fontSize:12,color:"var(--green)"}}>{d}</span>)}</div>}
+                  </div>
+                )}
                 <div style={{background:"var(--red-bg)",border:"1.5px solid var(--red)",borderRadius:"var(--r-md)",padding:"20px 24px",marginBottom:16}}>
                   <div style={{fontSize:14,fontWeight:700,color:"var(--red)",marginBottom:6}}>ICP Build Issue</div>
                   <div style={{fontSize:13,color:"var(--ink-1)",lineHeight:1.6}}>{sellerICP._error}</div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1214,6 +1214,11 @@ Do not introduce any claim, name, number, or title not present in the source. If
 is not in the source, omit it — never infer, estimate, or approximate. Every sentence you
 write must be traceable to a labeled source section.`;
 
+// Prod-safe stream diagnostics. console.* is stripped by the production build (vite.config drop:['console']),
+// so failures record here instead. Inspect with window.__cambreeDiag in DevTools. Never sent anywhere.
+const _cambreeDiag = [];
+function recordStreamDiag(d) { try { _cambreeDiag.push({ at: new Date().toISOString(), ...d }); if (_cambreeDiag.length > 20) _cambreeDiag.shift(); if (typeof window !== "undefined") window.__cambreeDiag = _cambreeDiag; } catch {} }
+
 async function streamAI(prompt, onChunk, maxTok=2000, { model = null, signal = null, system = null } = {}) {
   const sleep = ms => new Promise(r => setTimeout(r, ms));
   // Wrap the initial fetch in retry. Once the stream is open we let it run
@@ -1265,6 +1270,7 @@ async function streamAI(prompt, onChunk, maxTok=2000, { model = null, signal = n
   const decoder = new TextDecoder();
   let buffer = '';
   let fullText = '';
+  let _stopReason = null, _outputTokens = null;
   try {
     while (true) {
       const { done, value } = await reader.read();
@@ -1278,6 +1284,7 @@ async function streamAI(prompt, onChunk, maxTok=2000, { model = null, signal = n
         if (data === '[DONE]') continue;
         try {
           const event = JSON.parse(data);
+          if (event.type === 'message_delta') { _stopReason = event.delta?.stop_reason ?? _stopReason; _outputTokens = event.usage?.output_tokens ?? _outputTokens; }
           if (event.type === 'content_block_delta' && event.delta?.text) {
             fullText += event.delta.text;
             onChunk(fullText.replace(/<\/?cite[^>]*>/g, "").replace(/```(?:json)?\s*/gi, "").replace(/```\s*/g, "").replace(/<\/?thinking>/g, ""));
@@ -1298,8 +1305,9 @@ async function streamAI(prompt, onChunk, maxTok=2000, { model = null, signal = n
       try { return stripCitations(JSON.parse(candidate)); } catch { /* try repair */ }
       const san = candidate.replace(/[\u2018\u2019]/g,"'").replace(/[\u201C\u201D]/g,'"').replace(/[\u2013\u2014]/g,"-").replace(/[\u2026]/g,"...").replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g,"").replace(/,\s*([}\]])/g,"$1");
       try { return stripCitations(JSON.parse(san)); } catch { /* try repair */ }
-      try { return stripCitations(JSON.parse(repairJSON(san))); } catch(e) { console.warn("[streamAI] JSON parse/repair failed:", e?.message, "| preview:", (san||"").slice(0,200)); return null; }
+      try { return stripCitations(JSON.parse(repairJSON(san))); } catch(e) { recordStreamDiag({ fn: "streamAI", reason: "parse", stopReason: _stopReason, outputTokens: _outputTokens, maxTok, textLen: fullText.length, parseError: e?.message, tail: (san||"").slice(-160) }); console.warn("[streamAI] JSON parse/repair failed:", e?.message, "| preview:", (san||"").slice(0,200)); return null; }
     }
+    recordStreamDiag({ fn: "streamAI", reason: "no-json", stopReason: _stopReason, outputTokens: _outputTokens, maxTok, textLen: fullText.length, tail: fullText.slice(-160) });
     return null;
   } catch { return null; }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8189,6 +8189,19 @@ Return ONLY raw JSON:
     if (fullSessionMeteredRef.current) fullSessionMeteredRef.current = _normalizeSellerUrl(resolvedUrl || "");
   };
 
+  // Single exit for ICP build failures. Rules: (1) a complete prior ICP (no _loading) is preserved and annotated, never wiped;
+  // (2) a partial (_loading:true) or null becomes an _error card — _loading is always stripped so a render gate always matches;
+  // (3) the reason code from the last stream diagnostic is appended so prod users and support can see WHY without DevTools.
+  const icpFail = (msg) => {
+    const d = (typeof window !== "undefined" && Array.isArray(window.__cambreeDiag)) ? window.__cambreeDiag[window.__cambreeDiag.length - 1] : null;
+    const code = d?.reason === "parse" ? (d?.stopReason === "max_tokens" ? " [E-ICP-TRUNC]" : " [E-ICP-PARSE]") : d?.reason === "no-json" ? " [E-ICP-EMPTY]" : "";
+    setSellerICP(prev => {
+      if (prev && !prev._loading && prev.icp) return { ...prev, _warning: msg + code };
+      const { _loading, ...rest } = prev || {};
+      return { ...rest, _error: msg + code };
+    });
+  };
+
   const buildSellerICP = async(rawUrl, {forceRefresh=false, cacheOnly=false}={}) => {
     // Catch both "research-only" and "research-only.com" before any processing
     if (/^research-only(\.com)?$/i.test((rawUrl || "").trim())) return;
@@ -8485,11 +8498,17 @@ Return ONLY raw JSON:
         const err = raw?.error;
         console.warn("[ICP] Phase 2 error:", err ?? "(null response — model returned nothing)");
         if (err?.type === "usage_limit_exceeded" || err?.type === "max_limit_exceeded") {
-          setSellerICP(prev => prev || ({ _error: "You've reached your plan limit. Upgrade to continue building ICPs." }));
+          icpFail("You've reached your plan limit. Upgrade to continue building ICPs.");
           setIcpLoading(false); setIcpStatus(""); return;
         }
         if (err?.type === "unavailable" || err?.type === "overloaded_error") {
-          setSellerICP(prev => prev || ({ _error: "Our AI engine is temporarily overloaded. Click Regenerate ICP in a moment to retry." }));
+          icpFail("Our AI engine is temporarily overloaded. Click Regenerate ICP in a moment to retry.");
+        } else if (!err) {
+          // null return with no error object: clean stream end whose JSON did not parse (see window.__cambreeDiag). Issue #111.
+          icpFail("ICP build didn't complete — the response couldn't be read. Click Regenerate ICP to retry.");
+        } else {
+          // A defined error type this block doesn't recognise (e.g. rate_limit_error, invalid_request_error). Say so; don't call it 'busy'.
+          icpFail(`ICP build failed (${String(err.type || "error")}). Click Regenerate ICP to retry.`);
         }
         setIcpLoading(false); setIcpStatus(""); return;
       }
@@ -8610,18 +8629,18 @@ Return ONLY raw JSON:
           }
         }catch(e){
           console.warn("ICP JSON parse failed:",e.message,raw.slice(0,200));
-          setSellerICP(prev => prev || ({ _error: "ICP build returned an unexpected format. Click Regenerate ICP to try again — this usually resolves on retry." }));
+          icpFail("ICP build returned an unexpected format. Click Regenerate ICP to try again — this usually resolves on retry.");
         }
       } else {
         console.warn("ICP phase 2 returned no text content");
-        setSellerICP(prev => prev || ({ _error: "ICP build didn't return usable data. Click Regenerate ICP to try again." }));
+        icpFail("ICP build didn't return usable data. Click Regenerate ICP to try again.");
       }
     }catch(e){
       console.warn("ICP build phase 2 failed:",e.message);
       const isTimeout = e.message?.includes("timed out");
-      setSellerICP(prev => prev || ({ _error: isTimeout
+      icpFail(isTimeout
         ? "ICP build timed out — this happens when our AI engine is under heavy load. Click Regenerate ICP to try again."
-        : "ICP build failed — our AI engine may be temporarily busy. Click Regenerate ICP to retry." }));
+        : "ICP build failed — our AI engine may be temporarily busy. Click Regenerate ICP to retry.");
     }
     setIcpLoading(false);
     setIcpStatus("");


### PR DESCRIPTION
## Summary
Work Order A from the 2026-09-01 prod test run (evidence: `Cambree_Test_Results_ICP_2026-09-01.md`). Supersedes PR #112 (closed unmerged). Fixes issue #111.

Three independent defects made the ICP build failure mode worse than necessary:

1. `streamAI` discarded `message_delta` — `stop_reason` and `output_tokens` were never captured, making max_tokens truncation / malformed JSON / early close indistinguishable.
2. `vite.config drop:['console']` strips all `console.*` in prod — every diagnostic in the failure path was dead code where the bug actually fired.
3. Five `setSellerICP(prev => prev || …)` handlers could leave `_loading: true` behind — then `setIcpLoading(false)` fired and no render gate matched, producing a blank card with no Regenerate button.

This PR makes failures **observable in prod**, **always recoverable**, and **honest about what completed**.

## Commits

**Commit 1 — `streamAI`: capture `stop_reason` / `output_tokens`; prod-safe diag ring buffer**
- `_cambreeDiag` ring buffer (last 20 events, `window.__cambreeDiag` in DevTools, never transmitted)
- `message_delta` captured in SSE loop: `_stopReason` and `_outputTokens` now extracted
- `recordStreamDiag()` called on both failure paths (parse failure and no-json) with reason, stopReason, outputTokens, textLen, and 160-char tail

**Commit 2 — `icpFail` helper; close `err === undefined` hole**
- `icpFail(msg)` replaces all five `setSellerICP(prev => prev || …)` sites
- Guarantees: complete prior ICP is preserved + annotated (never wiped); partial/null becomes `_error` card with `_loading` always stripped; error code appended from `window.__cambreeDiag` (`[E-ICP-TRUNC]` / `[E-ICP-PARSE]` / `[E-ICP-EMPTY]`)
- Closes the #111 path: `else if (!err)` branch fires when `streamAI` returns `null` with no error object
- Unrecognised error types now surface their type string

**Commit 3 — render: show what streamed before the failure; `_warning` as a banner**
- `icpPreview` fields (sellerDescription, marketCategory, differentiators) render above the red error card when present — labelled "NOT SAVED, NOT USED FOR SCORING"
- `_warning` elevated from small inline text to amber banner (background + border)

## QA gate
- `npm run lint` — no App.jsx errors
- `npm run test:lint` and `npm run test:backtest` — 0 failures ✅
- Static: `grep 'setSellerICP(prev => prev || '` → zero hits ✅
- Static: `_loading` destructure present in `icpFail` ✅

Staging QA steps (per work order):
1. Force a parse failure (set Pass 2 `maxTok` to `600` locally, NOT committed), build ICP for `timetocollide.com` → expect red card `… [E-ICP-TRUNC]`, the "WHAT WE FOUND…" panel, Regenerate button, `window.__cambreeDiag[0].stopReason === "max_tokens"`
2. Regenerate over a complete ICP with the same forced failure → prior ICP stays rendered with amber `⚠ … [E-ICP-TRUNC]` banner
3. Happy path `99minds.io` → ICP builds, no banner, no diag entries with `reason:"parse"`
4. Session round-trip → no `_error`/`_warning` leaks into a saved good ICP

## Out of scope (Work Order B, issue #113)
Preventing the null — token budgets (`max_tokens` 4000 → 6000, `sellerResearch.slice` 6K → 14K, doc slice 2K → 6K) require Stage-0 validation. Apply after this PR is on staging.

Fixes #111