### PR TITLE
bugfix: ICP failures always land on an error card, never the empty state (#111)

### DIFF
--- a/.github/workflows/icp-stream-tests.yml
+++ b/.github/workflows/icp-stream-tests.yml
@@ -1,0 +1,38 @@
+name: icp-stream-tests
+
+# Regression guard for issue #111: the ICP build stream/failure paths.
+# Runs src/lib/icpStream.js + src/lib/icpFailure.js against a mocked
+# /api/claude-stream SSE service -- zero LLM cost, zero npm dependencies,
+# no network. Hard-fails on any assertion failure.
+
+on:
+  pull_request:
+    paths:
+      - 'src/lib/icpStream.js'
+      - 'src/lib/icpFailure.js'
+      - 'src/App.jsx'
+      - 'tests/icp-stream/**'
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/lib/icpStream.js'
+      - 'src/lib/icpFailure.js'
+      - 'src/App.jsx'
+  workflow_dispatch: {}
+
+jobs:
+  icp-stream-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      # No `npm install` -- the tests use only Node built-ins (web streams).
+      - name: Stream transport + JSON recovery
+        run: node tests/icp-stream/stream.test.js
+
+      - name: Failure classification + state invariants
+        run: node tests/icp-stream/failure.test.js

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
     "test:fitscores": "node tests/fit-check/golden-scores.js",
     "test:properties": "node tests/fit-check/properties.js",
     "test:ssrf": "node tests/fetch-ssrf/ssrf.test.js",
+    "test:icpstream": "node tests/icp-stream/stream.test.js && node tests/icp-stream/failure.test.js",
     "test:fitcheck": "npm run test:noop && npm run test:fitscores && npm run test:properties",
     "test:play": "node tests/the-play/eval.js",
     "test:regression": "node tests/fit-check/regression-sweep.js",
     "test:regression:full": "node tests/fit-check/regression-sweep.js --full",
-    "test": "npm run test:lint && npm run test:backtest && npm run test:golden"
+    "test": "npm run test:lint && npm run test:backtest && npm run test:icpstream && npm run test:golden"
   },
   "dependencies": {
     "fflate": "^0.8.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,8 @@ import SuperAdmin from "./components/SuperAdmin.jsx";
 import UserDashboard from "./components/UserDashboard.jsx";
 import S9SolutionFit from "./stages/S9_SolutionFit.jsx";
 import { computeFitScore, buildSignalExtractionPrompt, labelForScore } from "./lib/fitScoring.js";
+import { stripCitations, repairJSON, consumeClaudeSse, parseStreamJson } from "./lib/icpStream.js";
+import { icpErrorCode, icpFailureState, classifyIcpPhase2Error } from "./lib/icpFailure.js";
 
 // ── Sortable column header for Fit Check table ──
 function FitSortTh({ sortKey, sortDir, onSort, colKey, children, style }) {
@@ -553,16 +555,8 @@ function extractJsonWithKey(text, anchorKey) {
 
 // ── CITATION STRIPPER — web_search returns <cite index="...">text</cite> tags ─
 // Strip them globally from any AI response text before it enters state.
-function stripCitations(text) {
-  if (typeof text === "string") return text.replace(/<\/?cite[^>]*>/g, "");
-  if (Array.isArray(text)) return text.map(stripCitations);
-  if (text && typeof text === "object") {
-    const out = {};
-    for (const [k, v] of Object.entries(text)) out[k] = stripCitations(v);
-    return out;
-  }
-  return text;
-}
+// (function body moved to src/lib/icpStream.js — imported at the top of this file
+// so the stream failure paths are unit-testable; issue #111)
 
 // ── AUTH TOKEN — module-level so all AI helpers can include it ─────────────
 let _authToken = "";
@@ -1214,6 +1208,11 @@ Do not introduce any claim, name, number, or title not present in the source. If
 is not in the source, omit it — never infer, estimate, or approximate. Every sentence you
 write must be traceable to a labeled source section.`;
 
+// Prod-safe stream diagnostics. console.* is stripped by the production build (vite.config drop:['console']),
+// so failures record here instead. Inspect with window.__cambreeDiag in DevTools. Never sent anywhere.
+const _cambreeDiag = [];
+function recordStreamDiag(d) { try { _cambreeDiag.push({ at: new Date().toISOString(), ...d }); if (_cambreeDiag.length > 20) _cambreeDiag.shift(); if (typeof window !== "undefined") window.__cambreeDiag = _cambreeDiag; } catch {} }
+
 async function streamAI(prompt, onChunk, maxTok=2000, { model = null, signal = null, system = null } = {}) {
   const sleep = ms => new Promise(r => setTimeout(r, ms));
   // Wrap the initial fetch in retry. Once the stream is open we let it run
@@ -1261,47 +1260,23 @@ async function streamAI(prompt, onChunk, maxTok=2000, { model = null, signal = n
     } catch { /* non-critical */ }
     return null;
   }
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  let fullText = '';
+  // SSE read + JSON recovery live in src/lib/icpStream.js (issue #111) so both
+  // are unit-testable against a mocked stream. Behavior is unchanged: abort \u2192
+  // null; unreadable JSON \u2192 diag entry (window.__cambreeDiag) + null.
+  let streamed;
   try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop();
-      for (const line of lines) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6).trim();
-        if (data === '[DONE]') continue;
-        try {
-          const event = JSON.parse(data);
-          if (event.type === 'content_block_delta' && event.delta?.text) {
-            fullText += event.delta.text;
-            onChunk(fullText.replace(/<\/?cite[^>]*>/g, "").replace(/```(?:json)?\s*/gi, "").replace(/```\s*/g, "").replace(/<\/?thinking>/g, ""));
-          }
-        } catch { /* non-critical */ }
-      }
-    }
+    streamed = await consumeClaudeSse(response.body, onChunk);
   } catch (e) {
     if (e.name === 'AbortError') return null;
     throw e;
   }
-  try {
-    let cleaned = fullText.replace(/<\/?cite[^>]*>/g, "").replace(/```(?:json)?\s*/gi, "").replace(/```\s*/g, "").replace(/<\/?thinking>/g, "").trim();
-    const fb = cleaned.indexOf("{");
-    const lb = cleaned.lastIndexOf("}");
-    if (fb >= 0 && lb > fb) {
-      const candidate = cleaned.slice(fb, lb + 1);
-      try { return stripCitations(JSON.parse(candidate)); } catch { /* try repair */ }
-      const san = candidate.replace(/[\u2018\u2019]/g,"'").replace(/[\u201C\u201D]/g,'"').replace(/[\u2013\u2014]/g,"-").replace(/[\u2026]/g,"...").replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g,"").replace(/,\s*([}\]])/g,"$1");
-      try { return stripCitations(JSON.parse(san)); } catch { /* try repair */ }
-      try { return stripCitations(JSON.parse(repairJSON(san))); } catch(e) { console.warn("[streamAI] JSON parse/repair failed:", e?.message, "| preview:", (san||"").slice(0,200)); return null; }
-    }
+  const parsed = parseStreamJson(streamed.fullText);
+  if (parsed.failure) {
+    recordStreamDiag({ fn: "streamAI", stopReason: streamed.stopReason, outputTokens: streamed.outputTokens, maxTok, ...parsed.failure });
+    if (parsed.failure.reason === "parse") console.warn("[streamAI] JSON parse/repair failed:", parsed.failure.parseError, "| tail:", parsed.failure.tail);
     return null;
-  } catch { return null; }
+  }
+  return parsed.data;
 }
 
 // streamAIWithSearch: like streamAI but with web_search tool support.
@@ -1469,36 +1444,8 @@ async function callAI(prompt, { maxTokens = 5500, skipJsonSuffix = false, model:
 }
 
 // JSON repair: escapes unescaped quotes and raw newlines inside strings
-function repairJSON(s) {
-  let out="", inStr=false, esc=false;
-  for(let i=0;i<s.length;i++){
-    const ch=s[i];
-    if(esc){out+=ch;esc=false;continue;}
-    if(ch==="\\"){out+=ch;esc=true;continue;}
-    if(inStr){
-      if(ch==="\n"){out+="\\n";continue;}
-      if(ch==="\r"){out+="\\r";continue;}
-      if(ch==="\t"){out+="\\t";continue;}
-      if(ch==='"'){
-        let j=i+1;
-        while(j<s.length){
-          if(s[j]==="\n"||s[j]==="\r"||s[j]===" "||s[j]==="\t"){j++;continue;}
-          if(s[j]==="\\"){j+=2;continue;}
-          break;
-        }
-        const nxt=j<s.length?s[j]:"";
-        if(nxt===","||nxt==="}"||nxt==="]"||nxt===":"||nxt===""){inStr=false;out+=ch;}
-        else{out+='\\"';}
-        continue;
-      }
-      out+=ch;
-    }else{
-      if(ch==='"'){inStr=true;out+=ch;continue;}
-      out+=ch;
-    }
-  }
-  return out;
-}
+// repairJSON moved to src/lib/icpStream.js (issue #111) — imported at the top
+// of this file so the JSON-recovery ladder is unit-testable.
 
 // ── THE PLAY — pure helper functions (v2-staging) ────────────────────────────
 
@@ -8181,6 +8128,15 @@ Return ONLY raw JSON:
     if (fullSessionMeteredRef.current) fullSessionMeteredRef.current = _normalizeSellerUrl(resolvedUrl || "");
   };
 
+  // Single exit for ICP build failures. Rules: (1) a complete prior ICP (no _loading) is preserved and annotated, never wiped;
+  // (2) a partial (_loading:true) or null becomes an _error card — _loading is always stripped so a render gate always matches;
+  // (3) the reason code from the last stream diagnostic is appended so prod users and support can see WHY without DevTools.
+  // Code + state transition live in src/lib/icpFailure.js (unit-tested).
+  const icpFail = (msg) => {
+    const d = (typeof window !== "undefined" && Array.isArray(window.__cambreeDiag)) ? window.__cambreeDiag[window.__cambreeDiag.length - 1] : null;
+    setSellerICP(prev => icpFailureState(prev, msg + icpErrorCode(d)));
+  };
+
   const buildSellerICP = async(rawUrl, {forceRefresh=false, cacheOnly=false}={}) => {
     // Catch both "research-only" and "research-only.com" before any processing
     if (/^research-only(\.com)?$/i.test((rawUrl || "").trim())) return;
@@ -8476,13 +8432,11 @@ Return ONLY raw JSON:
       if (!raw || (typeof raw === "object" && raw.error)) {
         const err = raw?.error;
         console.warn("[ICP] Phase 2 error:", err ?? "(null response — model returned nothing)");
-        if (err?.type === "usage_limit_exceeded" || err?.type === "max_limit_exceeded") {
-          setSellerICP(prev => prev || ({ _error: "You've reached your plan limit. Upgrade to continue building ICPs." }));
-          setIcpLoading(false); setIcpStatus(""); return;
-        }
-        if (err?.type === "unavailable" || err?.type === "overloaded_error") {
-          setSellerICP(prev => prev || ({ _error: "Our AI engine is temporarily overloaded. Click Regenerate ICP in a moment to retry." }));
-        }
+        // Every branch — including err === undefined (issue #111) — yields a
+        // message, so the user always lands on an error card or an annotated
+        // ICP, never the "Build ICP Now" empty state. Ladder lives in
+        // src/lib/icpFailure.js (unit-tested).
+        icpFail(classifyIcpPhase2Error(err).message);
         setIcpLoading(false); setIcpStatus(""); return;
       }
       setIcpStatus("Processing results...");
@@ -8602,18 +8556,18 @@ Return ONLY raw JSON:
           }
         }catch(e){
           console.warn("ICP JSON parse failed:",e.message,raw.slice(0,200));
-          setSellerICP(prev => prev || ({ _error: "ICP build returned an unexpected format. Click Regenerate ICP to try again — this usually resolves on retry." }));
+          icpFail("ICP build returned an unexpected format. Click Regenerate ICP to try again — this usually resolves on retry.");
         }
       } else {
         console.warn("ICP phase 2 returned no text content");
-        setSellerICP(prev => prev || ({ _error: "ICP build didn't return usable data. Click Regenerate ICP to try again." }));
+        icpFail("ICP build didn't return usable data. Click Regenerate ICP to try again.");
       }
     }catch(e){
       console.warn("ICP build phase 2 failed:",e.message);
       const isTimeout = e.message?.includes("timed out");
-      setSellerICP(prev => prev || ({ _error: isTimeout
+      icpFail(isTimeout
         ? "ICP build timed out — this happens when our AI engine is under heavy load. Click Regenerate ICP to try again."
-        : "ICP build failed — our AI engine may be temporarily busy. Click Regenerate ICP to retry." }));
+        : "ICP build failed — our AI engine may be temporarily busy. Click Regenerate ICP to retry.");
     }
     setIcpLoading(false);
     setIcpStatus("");
@@ -15444,8 +15398,8 @@ Return ONLY raw JSON:
                           </span>
                         )}
                         {sellerICP?._warning && (
-                          <div style={{marginTop:6,fontSize:11,color:"var(--amber)",fontWeight:600}}>
-                            {sellerICP._warning}
+                          <div style={{marginTop:8,fontSize:12,color:"var(--amber)",fontWeight:700,background:"var(--amber-bg)",border:"1px solid var(--amber)",borderRadius:8,padding:"8px 12px"}}>
+                            ⚠ {sellerICP._warning}
                           </div>
                         )}
                       </>
@@ -15544,6 +15498,14 @@ Return ONLY raw JSON:
 
             {sellerICP?._error&&!sellerICP?.icp&&(
               <div style={{maxWidth:520,margin:"40px auto",textAlign:"center"}}>
+                {(icpPreview?.sellerDescription || icpPreview?.marketCategory || (icpPreview?.differentiators||[]).length>0) && (
+                  <div style={{textAlign:"left",background:"var(--bg-1)",border:"1px solid var(--line-0)",borderRadius:"var(--r-md)",padding:"14px 16px",marginBottom:14}}>
+                    <div style={{fontSize:10,fontWeight:700,letterSpacing:.6,color:"var(--ink-3)",marginBottom:8}}>WHAT WE FOUND BEFORE THE BUILD FAILED — NOT SAVED, NOT USED FOR SCORING</div>
+                    {icpPreview?.sellerDescription && <div style={{fontSize:13,color:"var(--ink-1)",lineHeight:1.6,marginBottom:8}}>{icpPreview.sellerDescription}</div>}
+                    {icpPreview?.marketCategory && <div style={{fontSize:12,color:"var(--ink-2)",marginBottom:8}}>{icpPreview.marketCategory}</div>}
+                    {(icpPreview?.differentiators||[]).length>0 && <div style={{display:"flex",flexWrap:"wrap",gap:6}}>{icpPreview.differentiators.map((d,i)=><span key={i} style={{background:"var(--green-bg)",border:"1px solid #2E6B2E44",borderRadius:20,padding:"3px 10px",fontSize:12,color:"var(--green)"}}>{d}</span>)}</div>}
+                  </div>
+                )}
                 <div style={{background:"var(--red-bg)",border:"1.5px solid var(--red)",borderRadius:"var(--r-md)",padding:"20px 24px",marginBottom:16}}>
                   <div style={{fontSize:14,fontWeight:700,color:"var(--red)",marginBottom:6}}>ICP Build Issue</div>
                   <div style={{fontSize:13,color:"var(--ink-1)",lineHeight:1.6}}>{sellerICP._error}</div>

--- a/src/lib/icpFailure.js
+++ b/src/lib/icpFailure.js
@@ -1,0 +1,54 @@
+// ── ICP FAILURE HANDLING — pure state logic for buildSellerICP (issue #111) ──
+// Extracted from App.jsx so the failure-classification and state-transition
+// rules are unit-testable (tests/icp-stream/failure.test.js). This module is
+// LIVE — App.jsx imports it. No React, no DOM.
+//
+// The #111 bug: when ICP Pass 2 returned null with no recognised error type,
+// no setSellerICP call fired, sellerICP stayed null (or _loading:true from
+// partial streaming), and setIcpLoading(false) revealed the "Build ICP Now"
+// empty state instead of an error card with a Regenerate path.
+
+// Maps the last stream diagnostic (window.__cambreeDiag entry) to a support
+// code appended to the user-facing message, so prod users can report WHY
+// without DevTools. TRUNC = max_tokens cutoff; PARSE = JSON present but
+// unreadable; EMPTY = stream ended with no JSON at all.
+export function icpErrorCode(diag) {
+  if (diag?.reason === "parse") return diag?.stopReason === "max_tokens" ? " [E-ICP-TRUNC]" : " [E-ICP-PARSE]";
+  if (diag?.reason === "no-json") return " [E-ICP-EMPTY]";
+  return "";
+}
+
+// Single state transition for every ICP build failure. Rules:
+// (1) a complete prior ICP (has .icp, not _loading) is preserved and annotated
+//     with _warning — never wiped;
+// (2) a partial (_loading:true) or null becomes an _error card — _loading is
+//     ALWAYS stripped so a render gate always matches (no dead blank state);
+// (3) the result therefore always renders either the annotated ICP panel or
+//     the error card with its Regenerate button.
+export function icpFailureState(prev, message) {
+  if (prev && !prev._loading && prev.icp) return { ...prev, _warning: message };
+  const { _loading, ...rest } = prev || {};
+  return { ...rest, _error: message };
+}
+
+// Classifies the Pass-2 result when streamAI returned null or an error object.
+// EVERY branch yields a message — the err === undefined hole (issue #111)
+// previously fell through with no state update at all.
+// kind: "limit" is terminal (upgrade required); everything else is retryable
+// via Regenerate.
+export function classifyIcpPhase2Error(err) {
+  if (err?.type === "usage_limit_exceeded" || err?.type === "max_limit_exceeded") {
+    return { kind: "limit", message: "You've reached your plan limit. Upgrade to continue building ICPs." };
+  }
+  if (err?.type === "unavailable" || err?.type === "overloaded_error") {
+    return { kind: "overloaded", message: "Our AI engine is temporarily overloaded. Click Regenerate ICP in a moment to retry." };
+  }
+  if (!err) {
+    // null return with no error object: clean stream end whose JSON did not
+    // parse (see window.__cambreeDiag). The original #111 path.
+    return { kind: "empty", message: "ICP build didn't complete — the response couldn't be read. Click Regenerate ICP to retry." };
+  }
+  // A defined error type this ladder doesn't recognise (e.g. rate_limit_error,
+  // invalid_request_error). Say so — don't call it "busy".
+  return { kind: "unrecognized", message: `ICP build failed (${String(err.type || "error")}). Click Regenerate ICP to retry.` };
+}

--- a/src/lib/icpStream.js
+++ b/src/lib/icpStream.js
@@ -1,0 +1,128 @@
+// ── ICP STREAM CORE — SSE transport + JSON recovery for streamAI (issue #111) ─
+// Extracted from App.jsx so the stream failure paths can be unit-tested against
+// a mocked /api/claude-stream response (tests/icp-stream/) with no live API call.
+// This module is LIVE — App.jsx imports it (like fitScoring.js). Keep it free of
+// React/DOM/network dependencies: pure functions plus the web-streams reader.
+
+// ── CITATION STRIPPER — web_search returns <cite index="...">text</cite> tags ─
+// Strip them globally from any AI response value before it enters state.
+export function stripCitations(text) {
+  if (typeof text === "string") return text.replace(/<\/?cite[^>]*>/g, "");
+  if (Array.isArray(text)) return text.map(stripCitations);
+  if (text && typeof text === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(text)) out[k] = stripCitations(v);
+    return out;
+  }
+  return text;
+}
+
+// Repairs the most common model-JSON defect: unescaped control characters and
+// stray double-quotes inside string values. Walks char-by-char tracking string
+// state; a quote inside a string only terminates it when followed by a
+// structural character (, } ] : or end).
+export function repairJSON(s) {
+  let out = "", inStr = false, esc = false;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (esc) { out += ch; esc = false; continue; }
+    if (ch === "\\") { out += ch; esc = true; continue; }
+    if (inStr) {
+      if (ch === "\n") { out += "\\n"; continue; }
+      if (ch === "\r") { out += "\\r"; continue; }
+      if (ch === "\t") { out += "\\t"; continue; }
+      if (ch === '"') {
+        let j = i + 1;
+        while (j < s.length) {
+          if (s[j] === "\n" || s[j] === "\r" || s[j] === " " || s[j] === "\t") { j++; continue; }
+          if (s[j] === "\\") { j += 2; continue; }
+          break;
+        }
+        const nxt = j < s.length ? s[j] : "";
+        if (nxt === "," || nxt === "}" || nxt === "]" || nxt === ":" || nxt === "") { inStr = false; out += ch; }
+        else { out += '\\"'; }
+        continue;
+      }
+      out += ch;
+    } else {
+      if (ch === '"') { inStr = true; out += ch; continue; }
+      out += ch;
+    }
+  }
+  return out;
+}
+
+// Presentation cleanup applied to streamed text before it reaches onChunk or
+// the final parse: cite tags, markdown fences, thinking tags.
+export function cleanStreamText(text) {
+  return text
+    .replace(/<\/?cite[^>]*>/g, "")
+    .replace(/```(?:json)?\s*/gi, "")
+    .replace(/```\s*/g, "")
+    .replace(/<\/?thinking>/g, "");
+}
+
+// Reads an Anthropic SSE body (a ReadableStream) to completion.
+// Captures message_delta so callers can distinguish max_tokens truncation from
+// a parse failure — before issue #111 stop_reason was silently discarded.
+// Throws on reader errors (including AbortError) — the caller owns that policy.
+export async function consumeClaudeSse(body, onChunk) {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let fullText = "";
+  let stopReason = null, outputTokens = null;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop();
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      const data = line.slice(6).trim();
+      if (data === "[DONE]") continue;
+      try {
+        const event = JSON.parse(data);
+        if (event.type === "message_delta") {
+          stopReason = event.delta?.stop_reason ?? stopReason;
+          outputTokens = event.usage?.output_tokens ?? outputTokens;
+        }
+        if (event.type === "content_block_delta" && event.delta?.text) {
+          fullText += event.delta.text;
+          onChunk(cleanStreamText(fullText));
+        }
+      } catch { /* non-critical */ }
+    }
+  }
+  return { fullText, stopReason, outputTokens };
+}
+
+// Final parse of the accumulated stream text: raw → sanitized → repaired.
+// Returns { data } on success, or { failure } describing WHY it could not be
+// read — reason "parse" (JSON present but unreadable, e.g. truncation) or
+// "no-json" (no {...} at all). The failure object feeds the diag ring buffer
+// and the [E-ICP-*] user-facing error codes.
+export function parseStreamJson(fullText) {
+  const cleaned = cleanStreamText(fullText).trim();
+  const fb = cleaned.indexOf("{");
+  const lb = cleaned.lastIndexOf("}");
+  if (fb >= 0 && lb > fb) {
+    const candidate = cleaned.slice(fb, lb + 1);
+    try { return { data: stripCitations(JSON.parse(candidate)) }; } catch { /* try sanitize */ }
+    const san = candidate
+      .replace(/[‘’]/g, "'")
+      .replace(/[“”]/g, '"')
+      .replace(/[–—]/g, "-")
+      .replace(/[…]/g, "...")
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, "")
+      .replace(/,\s*([}\]])/g, "$1");
+    try { return { data: stripCitations(JSON.parse(san)) }; } catch { /* try repair */ }
+    try { return { data: stripCitations(JSON.parse(repairJSON(san))) }; }
+    catch (e) {
+      return { failure: { reason: "parse", parseError: e?.message, textLen: fullText.length, tail: (san || "").slice(-160) } };
+    }
+  }
+  return { failure: { reason: "no-json", textLen: fullText.length, tail: fullText.slice(-160) } };
+}

--- a/tests/icp-stream/failure.test.js
+++ b/tests/icp-stream/failure.test.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/* global process */
+// tests/icp-stream/failure.test.js — regression tests for issue #111 (state layer).
+//
+// The bug: ICP Pass 2 returning null with no recognised error type left
+// sellerICP untouched → "Build ICP Now" empty state instead of an error card.
+// These tests pin the two invariants that prevent it:
+//   1. classifyIcpPhase2Error yields a message for EVERY input — including
+//      err === undefined (the #111 hole) and unrecognised error types.
+//   2. icpFailureState never returns a dead state: the result always renders
+//      either the annotated ICP panel (complete prior ICP + _warning) or the
+//      error card (_error, _loading always stripped).
+//
+// Pure functions, no network, no DOM. Usage: node tests/icp-stream/failure.test.js
+
+import { icpErrorCode, icpFailureState, classifyIcpPhase2Error } from "../../src/lib/icpFailure.js";
+import { consumeClaudeSse, parseStreamJson } from "../../src/lib/icpStream.js";
+import { claudeTextEvents, mockClaudeStreamResponse } from "./mock-claude-stream.js";
+
+let passed = 0, failed = 0;
+const failures = [];
+function assert(cond, label) {
+  if (cond) { console.log(`  PASS  ${label}`); passed++; }
+  else { console.error(`  FAIL  ${label}`); failures.push(label); failed++; }
+}
+
+// Mirrors the App.jsx render gates for the ICP area of Step 2.
+// Pre-#111, a state could match NONE of these (null/partial sellerICP with
+// icpLoading false) → the misleading "Build ICP Now" empty state.
+function rendersSomethingActionable(sellerICP) {
+  const errorCard = !!(sellerICP?._error && !sellerICP?.icp);       // red card + Regenerate
+  const icpPanel = !!(sellerICP?.icp && !sellerICP?._loading);      // ICP panel (± _warning banner)
+  return errorCard || icpPanel;
+}
+
+console.log("\n── classifyIcpPhase2Error covers every branch ──────────────────");
+{
+  const r = classifyIcpPhase2Error(undefined);
+  assert(r.kind === "empty" && r.message.includes("Regenerate"), "err undefined (the #111 hole) → retryable message");
+  assert(classifyIcpPhase2Error(null).kind === "empty", "err null → same branch");
+}
+{
+  assert(classifyIcpPhase2Error({ type: "usage_limit_exceeded" }).kind === "limit", "usage_limit_exceeded → limit");
+  assert(classifyIcpPhase2Error({ type: "max_limit_exceeded" }).kind === "limit", "max_limit_exceeded → limit");
+  assert(classifyIcpPhase2Error({ type: "usage_limit_exceeded" }).message.includes("plan limit"), "limit message mentions plan limit");
+}
+{
+  assert(classifyIcpPhase2Error({ type: "overloaded_error" }).kind === "overloaded", "overloaded_error → overloaded");
+  assert(classifyIcpPhase2Error({ type: "unavailable" }).kind === "overloaded", "unavailable → overloaded");
+}
+{
+  const r = classifyIcpPhase2Error({ type: "rate_limit_error" });
+  assert(r.kind === "unrecognized" && r.message.includes("rate_limit_error"), "unrecognised type surfaces its type string");
+  assert(classifyIcpPhase2Error({}).message.includes("(error)"), "error object without type → generic 'error' label");
+  assert(classifyIcpPhase2Error({ type: "invalid_request_error" }).message.includes("Regenerate"), "unrecognised type still offers Regenerate");
+}
+{
+  // Exhaustive: every input yields a non-empty message. No silent fall-through.
+  const inputs = [undefined, null, {}, { type: "" }, { type: "anything_else" }, { type: "usage_limit_exceeded" }, { type: "overloaded_error" }];
+  assert(inputs.every(e => (classifyIcpPhase2Error(e).message || "").length > 10), "every input produces a message (no silent fall-through)");
+}
+
+console.log("\n── icpErrorCode maps diagnostics to support codes ──────────────");
+{
+  assert(icpErrorCode({ reason: "parse", stopReason: "max_tokens" }) === " [E-ICP-TRUNC]", "parse + max_tokens → TRUNC");
+  assert(icpErrorCode({ reason: "parse", stopReason: "end_turn" }) === " [E-ICP-PARSE]", "parse + end_turn → PARSE");
+  assert(icpErrorCode({ reason: "parse" }) === " [E-ICP-PARSE]", "parse + no stopReason → PARSE");
+  assert(icpErrorCode({ reason: "no-json" }) === " [E-ICP-EMPTY]", "no-json → EMPTY");
+  assert(icpErrorCode(null) === "", "no diagnostic → no code");
+  assert(icpErrorCode(undefined) === "", "undefined diagnostic → no code");
+}
+
+console.log("\n── icpFailureState never produces a dead state ─────────────────");
+const MSG = "ICP build didn't complete — the response couldn't be read. Click Regenerate ICP to retry.";
+{
+  const next = icpFailureState(null, MSG);
+  assert(next._error === MSG, "prev null → error card state");
+  assert(!("_loading" in next), "prev null → no _loading key");
+  assert(rendersSomethingActionable(next), "prev null → renders error card (was: empty state, #111)");
+}
+{
+  const partial = { _loading: true, sellerDescription: "Acme is a B2B analytics platform", marketCategory: "Analytics" };
+  const next = icpFailureState(partial, MSG);
+  assert(next._error === MSG, "partial (_loading) → error card state");
+  assert(!("_loading" in next), "partial → _loading ALWAYS stripped");
+  assert(next.sellerDescription === partial.sellerDescription, "partial fields preserved for diagnostics");
+  assert(rendersSomethingActionable(next), "partial → renders error card (was: invisible partial, #111 secondary)");
+}
+{
+  const complete = { sellerName: "Acme", icp: { industries: ["SaaS"] }, sellerDescription: "..." };
+  const next = icpFailureState(complete, MSG + " [E-ICP-TRUNC]");
+  assert(next._warning === MSG + " [E-ICP-TRUNC]", "complete prior ICP → annotated with _warning");
+  assert(!next._error, "complete prior ICP → NOT downgraded to error card");
+  assert(next.icp === complete.icp, "complete prior ICP → data preserved, never wiped");
+  assert(rendersSomethingActionable(next), "complete prior ICP → still renders the ICP panel");
+}
+{
+  // A prior ICP that is mid-regeneration (_loading:true but has .icp from a
+  // previous build) must become an error card, not stay invisible.
+  const regenerating = { _loading: true, icp: { industries: ["SaaS"] }, sellerName: "Acme" };
+  const next = icpFailureState(regenerating, MSG);
+  assert(!("_loading" in next), "regenerating prior ICP → _loading stripped");
+  assert(rendersSomethingActionable(next), "regenerating prior ICP → renders something actionable");
+}
+{
+  // Invariant sweep across representative prev shapes.
+  const prevs = [null, undefined, {}, { _loading: true }, { _error: "old error" }, { _warning: "old warning" },
+    { _loading: true, sellerDescription: "x" }, { sellerName: "A", icp: {} }, { sellerName: "A", icp: {}, _warning: "w" }];
+  assert(prevs.every(p => rendersSomethingActionable(icpFailureState(p, MSG))), "INVARIANT: every prev shape → an actionable render state");
+  assert(prevs.every(p => !("_loading" in icpFailureState(p, MSG))), "INVARIANT: _loading never survives a failure");
+}
+
+console.log("\n── end-to-end: mocked truncated stream → user-facing state ─────");
+{
+  // Full #111 chain with the mocked live service: truncated stream → parse
+  // failure → diag → error code → state. This is the scenario from the issue
+  // repro (thin web-search results / new domain).
+  const truncated = '{"sellerName": "Acme", "icp": {"industries": ["SaaS"]}, "desc": "cut off he';
+  const response = mockClaudeStreamResponse(claudeTextEvents(truncated, { stopReason: "max_tokens", outputTokens: 6500 }));
+  const streamed = await consumeClaudeSse(response.body, () => {});
+  const parsed = parseStreamJson(streamed.fullText);
+  assert(!!parsed.failure, "truncated stream fails parse");
+  const diag = { ...parsed.failure, stopReason: streamed.stopReason }; // what recordStreamDiag stores
+  const msg = classifyIcpPhase2Error(undefined).message + icpErrorCode(diag); // streamAI returned null, no error object
+  const state = icpFailureState(null, msg);
+  assert(state._error?.includes("[E-ICP-TRUNC]"), "user sees the TRUNC support code");
+  assert(state._error?.includes("Regenerate"), "user sees a Regenerate path");
+  assert(rendersSomethingActionable(state), "end-to-end: error card renders, never the empty state");
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) { console.error("Failures:\n  " + failures.join("\n  ")); process.exit(1); }

--- a/tests/icp-stream/mock-claude-stream.js
+++ b/tests/icp-stream/mock-claude-stream.js
@@ -1,0 +1,59 @@
+// tests/icp-stream/mock-claude-stream.js — mock of the live /api/claude-stream
+// service (the Anthropic SSE proxy). Builds real Response objects whose body is
+// a ReadableStream emitting Anthropic Messages API SSE events, so the stream
+// transport in src/lib/icpStream.js is exercised exactly as in prod — byte
+// chunking, event framing, [DONE] terminator — with zero network access and
+// zero API spend.
+
+const encoder = new TextEncoder();
+
+export function sseFrame(event) {
+  return `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+// Standard event sequence for a text completion, mirroring what the proxy
+// relays from Anthropic: message_start → content_block_start → N deltas →
+// content_block_stop → message_delta (carries stop_reason + output_tokens).
+export function claudeTextEvents(text, { stopReason = "end_turn", outputTokens = 250, pieces = 8 } = {}) {
+  const events = [
+    { type: "message_start", message: { id: "msg_mock", model: "claude-sonnet-4-6", usage: { input_tokens: 1200 } } },
+    { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+  ];
+  const step = Math.max(1, Math.ceil(text.length / pieces));
+  for (let i = 0; i < text.length; i += step) {
+    events.push({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: text.slice(i, i + step) } });
+  }
+  events.push({ type: "content_block_stop", index: 0 });
+  events.push({ type: "message_delta", delta: { stop_reason: stopReason, stop_sequence: null }, usage: { output_tokens: outputTokens } });
+  events.push({ type: "message_stop" });
+  return events;
+}
+
+// Builds the Response a caller of /api/claude-stream would receive.
+// chunkSize deliberately misaligns byte chunks with SSE frame boundaries so the
+// buffering logic in consumeClaudeSse is genuinely tested.
+export function mockClaudeStreamResponse(events, { chunkSize = 17, status = 200, extraRaw = "" } = {}) {
+  const raw = events.map(sseFrame).join("") + extraRaw + "data: [DONE]\n\n";
+  const stream = new ReadableStream({
+    start(controller) {
+      for (let i = 0; i < raw.length; i += chunkSize) {
+        controller.enqueue(encoder.encode(raw.slice(i, i + chunkSize)));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, { status, headers: { "Content-Type": "text/event-stream" } });
+}
+
+// fetch-shaped mock for the whole service: returns a function with the same
+// call signature as fetch("/api/claude-stream", init) that resolves to the SSE
+// Response above and records the request body for assertions.
+export function mockClaudeStreamService(events, opts = {}) {
+  const calls = [];
+  const service = async (url, init = {}) => {
+    calls.push({ url, body: init.body ? JSON.parse(init.body) : null });
+    return mockClaudeStreamResponse(events, opts);
+  };
+  service.calls = calls;
+  return service;
+}

--- a/tests/icp-stream/stream.test.js
+++ b/tests/icp-stream/stream.test.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/* global process */
+// tests/icp-stream/stream.test.js — regression tests for issue #111 (stream layer).
+//
+// Exercises src/lib/icpStream.js against a MOCKED /api/claude-stream service
+// (tests/icp-stream/mock-claude-stream.js) — real ReadableStream + SSE framing,
+// no network, no Anthropic spend. Covers:
+//   - happy path: chunked JSON parses; progressive onChunk text is cleaned
+//   - message_delta capture: stop_reason / output_tokens no longer discarded
+//   - max_tokens truncation → failure reason "parse" (feeds [E-ICP-TRUNC])
+//   - prose-only / empty output → failure reason "no-json" ([E-ICP-EMPTY])
+//   - recovery ladder: markdown fences, smart quotes, trailing commas,
+//     unescaped newlines, cite tags
+//
+// Usage: node tests/icp-stream/stream.test.js   (exit 0 = green)
+
+import { consumeClaudeSse, parseStreamJson, cleanStreamText, stripCitations, repairJSON } from "../../src/lib/icpStream.js";
+import { claudeTextEvents, mockClaudeStreamService, mockClaudeStreamResponse } from "./mock-claude-stream.js";
+
+let passed = 0, failed = 0;
+const failures = [];
+function assert(cond, label) {
+  if (cond) { console.log(`  PASS  ${label}`); passed++; }
+  else { console.error(`  FAIL  ${label}`); failures.push(label); failed++; }
+}
+
+// Drives the same path streamAI takes after opening the response: consume the
+// SSE body, then run the JSON recovery ladder.
+async function runStream(events, opts = {}) {
+  const service = mockClaudeStreamService(events, opts);
+  const response = await service("/api/claude-stream", { method: "POST", body: JSON.stringify({ model: "claude-sonnet-4-6" }) });
+  const chunks = [];
+  const streamed = await consumeClaudeSse(response.body, (t) => chunks.push(t));
+  return { streamed, parsed: parseStreamJson(streamed.fullText), chunks, service };
+}
+
+const GOOD_ICP = { sellerName: "Acme Analytics", sellerDescription: "B2B analytics platform", icp: { industries: ["SaaS"], companySize: "200-1000" } };
+
+console.log("\n── happy path ──────────────────────────────────────────────────");
+{
+  const { streamed, parsed, chunks } = await runStream(claudeTextEvents(JSON.stringify(GOOD_ICP)));
+  assert(parsed.data && !parsed.failure, "valid JSON stream → data, no failure");
+  assert(parsed.data?.sellerName === "Acme Analytics", "parsed object carries sellerName");
+  assert(parsed.data?.icp?.industries?.[0] === "SaaS", "nested icp fields survive");
+  assert(streamed.stopReason === "end_turn", "message_delta stop_reason captured (was discarded pre-#111)");
+  assert(streamed.outputTokens === 250, "message_delta output_tokens captured");
+  assert(chunks.length > 1, "onChunk fired progressively across SSE deltas");
+  assert(chunks[chunks.length - 1].includes("Acme Analytics"), "final onChunk text contains full payload");
+}
+
+{
+  // Byte chunks misaligned with SSE frames — 1-byte chunks is the worst case.
+  const { parsed } = await runStream(claudeTextEvents(JSON.stringify(GOOD_ICP), { pieces: 3 }), { chunkSize: 1 });
+  assert(parsed.data?.sellerName === "Acme Analytics", "1-byte transport chunks reassemble correctly");
+}
+
+console.log("\n── truncation (max_tokens) → reason 'parse' ────────────────────");
+{
+  // Cut mid-string after a nested object closed, so a '}' exists but the
+  // candidate slice is unparseable — the exact #111 production shape.
+  const truncated = '{"sellerName": "Acme Analytics", "icp": {"industries": ["SaaS"]}, "sellerDescription": "B2B analytics pla';
+  const { streamed, parsed } = await runStream(claudeTextEvents(truncated, { stopReason: "max_tokens", outputTokens: 6500 }));
+  assert(!parsed.data && parsed.failure, "truncated JSON → failure, not silent null");
+  assert(parsed.failure?.reason === "parse", "failure reason is 'parse'");
+  assert(streamed.stopReason === "max_tokens", "stop_reason 'max_tokens' captured for diagnosis");
+  assert(typeof parsed.failure?.tail === "string" && parsed.failure.tail.length > 0, "failure carries a tail excerpt for diagnostics");
+  assert(parsed.failure?.textLen === truncated.length, "failure records text length");
+}
+
+console.log("\n── empty / prose-only → reason 'no-json' ───────────────────────");
+{
+  const { parsed } = await runStream(claudeTextEvents("I could not find enough information about this company to build an ICP."));
+  assert(parsed.failure?.reason === "no-json", "prose-only response → 'no-json'");
+}
+{
+  // Stream that produced no text at all (e.g. thin web-search results).
+  const { streamed, parsed } = await runStream(claudeTextEvents("", { pieces: 1 }));
+  assert(streamed.fullText === "", "empty stream yields empty fullText");
+  assert(parsed.failure?.reason === "no-json", "empty stream → 'no-json'");
+}
+
+console.log("\n── JSON recovery ladder ────────────────────────────────────────");
+{
+  const fenced = "```json\n" + JSON.stringify(GOOD_ICP) + "\n```";
+  const { parsed } = await runStream(claudeTextEvents(fenced));
+  assert(parsed.data?.sellerName === "Acme Analytics", "markdown-fenced JSON recovered");
+}
+{
+  const smart = '{"sellerName": "Acme “Analytics”", "note": "AI—driven", "list": ["a", "b",]}';
+  const { parsed } = await runStream(claudeTextEvents(smart));
+  assert(parsed.data && parsed.data.list?.length === 2, "smart quotes + trailing comma sanitized");
+}
+{
+  const withNewline = '{"sellerName": "Acme", "sellerDescription": "line one\nline two"}';
+  // Raw newline inside a JSON string — only repairJSON can save this.
+  const { parsed } = await runStream(claudeTextEvents(withNewline, { pieces: 2 }));
+  assert(parsed.data?.sellerDescription?.includes("line one"), "unescaped newline in string repaired");
+}
+{
+  const cited = '{"sellerName": "<cite index="1">Acme Analytics</cite>", "icp": {}}';
+  const { parsed } = await runStream(claudeTextEvents(cited));
+  assert(parsed.data?.sellerName === "Acme Analytics", "cite tags stripped from parsed values");
+}
+{
+  // Garbage interleaved in the transport (comment lines, blank keepalives)
+  // must not corrupt the accumulated text.
+  const events = claudeTextEvents(JSON.stringify(GOOD_ICP), { pieces: 2 });
+  const response = mockClaudeStreamResponse(events, { extraRaw: ": keepalive\n\ndata: {not json}\n\n" });
+  const streamed = await consumeClaudeSse(response.body, () => {});
+  const parsed = parseStreamJson(streamed.fullText);
+  assert(parsed.data?.sellerName === "Acme Analytics", "keepalives and malformed data lines ignored");
+}
+
+console.log("\n── helper units ────────────────────────────────────────────────");
+{
+  assert(cleanStreamText("<thinking></thinking>```json\n{}```") === "{}", "cleanStreamText strips fences and thinking tags");
+  assert(stripCitations({ a: ['<cite index="2">x</cite>'] }).a[0] === "x", "stripCitations recurses arrays/objects");
+  const repaired = repairJSON('{"k": "a\tb"}');
+  assert(JSON.parse(repaired).k === "a\\tb".replace("\\t", "\t"), "repairJSON escapes tabs inside strings");
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) { console.error("Failures:\n  " + failures.join("\n  ")); process.exit(1); }


### PR DESCRIPTION
## Summary

Fixes #111 — when ICP Pass 2 returned `null` with no recognised error type, no `setSellerICP` call fired and the user landed on the misleading "Build ICP Now" empty state instead of an error card.

Applies the fix from PR #121 (`bugfix/issue-111-icp-observable-failure`) and adds the regression test layer it was missing. If this merges, #121 should be closed as superseded.

## The fix (commit 1)

- `streamAI` captures `message_delta` (`stop_reason` / `output_tokens`) and records failures in a prod-safe ring buffer (`window.__cambreeDiag`) — `vite.config drop:['console']` made the old console diagnostics dead code in prod.
- Single `icpFail` exit for every Pass-2 failure, including the `err === undefined` hole: the user always gets an error card with a Regenerate button and a support code (`[E-ICP-TRUNC]` / `[E-ICP-PARSE]` / `[E-ICP-EMPTY]`), `_loading` is always stripped, a complete prior ICP is annotated (never wiped), and streamed `icpPreview` fields render above the error card labelled "NOT SAVED, NOT USED FOR SCORING".
- Unrecognised error types surface their type string instead of being called "busy".

**Testability refactor (behavior unchanged):** the pure logic is extracted into live modules App.jsx imports (same pattern as `fitScoring.js`):
- `src/lib/icpStream.js` — SSE transport (`consumeClaudeSse`), JSON recovery ladder (`parseStreamJson`), plus the moved `stripCitations` / `repairJSON`
- `src/lib/icpFailure.js` — `classifyIcpPhase2Error`, `icpErrorCode`, `icpFailureState`

## The tests (commit 2) — 60 assertions, zero network, zero API spend

- `tests/icp-stream/mock-claude-stream.js` mocks the live `/api/claude-stream` Anthropic proxy: real `Response` + `ReadableStream` SSE framing, byte chunks deliberately misaligned with event boundaries.
- `stream.test.js` (24): happy path, `message_delta` capture, max_tokens truncation → `parse`, prose/empty → `no-json`, recovery ladder (fences, smart quotes, trailing commas, raw newlines, cite tags), keepalive/garbage tolerance.
- `failure.test.js` (36): every classify branch incl. the #111 hole; error-code mapping; state invariants (**never a dead render state, `_loading` never survives a failure, a complete prior ICP is never wiped**); end-to-end mocked truncated stream → `[E-ICP-TRUNC]` error card.
- Wired in as `npm run test:icpstream` (free tier, runs in `npm test` before the golden set) + new CI workflow `icp-stream-tests.yml` on PRs touching the stream modules, App.jsx, or the tests.

## QA gate

- `node tests/icp-stream/stream.test.js` + `failure.test.js` — 60/60 green
- `npm run test:lint`, `npm run test:backtest` — 0 failures
- `npm run build` — succeeds
- `npx eslint src/App.jsx` — exactly at the staging baseline (no new problems); new lib/test files lint clean
- Golden set not run (paid tier, per test policy); no scoring or brief-pipeline behavior touched, so Stage-0 validation is not triggered

Fixes #111
