### PR TITLE
feature: API platform — API Gateway + Lambda + shared guard, contact pilot (#86)

### DIFF
--- a/.github/workflows/api-aws-tests.yml
+++ b/.github/workflows/api-aws-tests.yml
@@ -1,0 +1,41 @@
+name: api-aws-tests
+
+# Unit tests for the AWS API platform (issue #86): shared guard (origin/CORS/
+# JWT/caps), the APIGW adapter, and response parity of ported endpoints
+# against their Vercel originals. Live services (Supabase JWKS + REST) are
+# mocked -- zero network, zero npm dependencies. Also verifies the Lambda
+# bundles still build, since terraform plan depends on that.
+
+on:
+  pull_request:
+    paths:
+      - 'api-aws/**'
+      - 'api/_guard.js'
+      - 'api/contact.js'
+      - 'tests/api-aws/**'
+  push:
+    branches: [ main ]
+    paths:
+      - 'api-aws/**'
+  workflow_dispatch: {}
+
+jobs:
+  api-aws-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      # Tests import api-aws sources directly -- Node built-ins only.
+      - name: Shared guard + adapter
+        run: node tests/api-aws/guard.test.js
+
+      - name: Contact endpoint parity
+        run: node tests/api-aws/contact.test.js
+
+      - name: Lambda bundles build
+        working-directory: api-aws
+        run: npm ci && npm run build

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,13 +13,16 @@
 
 name: terraform
 
+# api-aws/** is in the trigger paths (issue #86): Lambda code is zipped into
+# the plan via archive_file, so a code-only merge deploys through the same
+# plan/apply pipeline as infra changes.
 on:
   pull_request:
     branches: [dev, staging, main]
-    paths: ["infra/envs/**", "infra/modules/**"]
+    paths: ["infra/envs/**", "infra/modules/**", "api-aws/**"]
   push:
     branches: [dev, staging, main]
-    paths: ["infra/envs/**", "infra/modules/**"]
+    paths: ["infra/envs/**", "infra/modules/**", "api-aws/**"]
 
 permissions:
   id-token: write # OIDC token for aws-actions/configure-aws-credentials
@@ -62,6 +65,16 @@ jobs:
         with:
           terraform_version: ${{ env.TF_VERSION }}
           terraform_wrapper: false
+
+      # Lambda bundles must exist before plan: archive_file zips api-aws/dist
+      # at plan time (infra/modules/api). Contained npm project — no root deps.
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: "22"
+
+      - name: Build Lambda bundles
+        working-directory: api-aws
+        run: npm ci && npm run build
 
       - name: Terraform init
         working-directory: infra/envs/${{ env.TF_ENV }}
@@ -138,6 +151,16 @@ jobs:
         with:
           terraform_version: ${{ env.TF_VERSION }}
           terraform_wrapper: false
+
+      # Same build as the plan job: the zip hashed into the plan is the zip
+      # that gets applied.
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: "22"
+
+      - name: Build Lambda bundles
+        working-directory: api-aws
+        run: npm ci && npm run build
 
       - name: Terraform init
         working-directory: infra/envs/${{ env.TF_ENV }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,9 @@ api/                         # Vercel serverless functions (underscore files = s
 ├── admin.js + _admin-action.js  # superuser-only (SUPERUSER_EMAIL) analytics/actions
 └── cron-*.js                # 3 Vercel crons (CRON_SECRET): monthly token reset,
                              #   weekly data refresh, weekly seller profiles
+api-aws/                     # AWS Lambda ports of api/ endpoints (issue #86, strangler pattern —
+                             #   Vercel api/ stays live; shared/ = ported guard/usage/adapter/secrets;
+                             #   deployed by infra/modules/api via the Terraform pipeline; see its README)
 supabase/migrations/         # 32 sequential SQL migrations (orgs, RLS, usage log, data-science tables)
 scripts/                     # ops: nightly-backup, check-rls, pl.mjs (P&L), smoke-brief,
                              #   variance diagnostics, consistency/ drift harness
@@ -100,7 +103,7 @@ docs/archive/                # historical session/audit/release logs (see index 
 ### Environment variables
 
 Server (`process.env`): `ANTHROPIC_API_KEY`, `SUPABASE_SERVICE_KEY`, `SUPABASE_JWT_SECRET`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_{STARTER,PRO,TEAM,ENTERPRISE}`, `HUBSPOT_CLIENT_ID/SECRET`, `HUBSPOT_TOKEN_KEY`, `APOLLO_API_KEY`, `CRON_SECRET`, `SUPERUSER_EMAIL`, `ALLOW_GUEST`.
-Client (`import.meta.env`): `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_APP_URL`.
+Client (`import.meta.env`): `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_APP_URL`, `VITE_API_URL` (API origin, issue #83; empty = same-origin), `VITE_API_ENDPOINT_ORIGINS` (JSON per-endpoint origin overrides for AWS-migrated endpoints, issue #86).
 
 **`ANTHROPIC_API_KEY` must never get a `VITE_` prefix** — that would bundle it into the browser (this exact leak happened once; the v100 proxy architecture exists to prevent it). The Supabase anon key is intentionally `VITE_`-prefixed and safe to expose.
 

--- a/api-aws/README.md
+++ b/api-aws/README.md
@@ -1,0 +1,127 @@
+# api-aws/ — AWS Lambda API sources (issue #86)
+
+Lambda sources for the Vercel → AWS function migration (Phase 3+,
+docs/aws-migration-plan.md §8). **Vercel's `api/` directory stays live and
+untouched** — endpoints move here one at a time (strangler pattern), and the
+Vercel copy of an endpoint is deleted only in the final conversion issue.
+
+## Layout
+
+```
+api-aws/
+├── shared/            # bundled into every function (see decision record below)
+│   ├── guard.js       # port of api/_guard.js: origin allowlist, CORS, JWT (HS256 + JWKS), caps
+│   ├── usage.js       # port of api/_usage.js: api_usage_log via Supabase REST
+│   ├── adapter.js     # APIGW HTTP API (payload v2) event/response ⇄ Vercel (req, res)
+│   └── secrets.js     # cold-start Secrets Manager load → process.env
+├── contact/index.js   # pilot endpoint (issue #86)
+├── build.mjs          # esbuild: <name>/index.js → dist/<name>/index.mjs
+└── package.json       # esbuild only; `npm run build`
+```
+
+Each subdirectory containing an `index.js` is an endpoint, deployed as one
+Lambda routed at `/api/<name>` by `infra/modules/api` (route paths mirror
+Vercel so the client swap is mechanical).
+
+## Decision record: shared code is a **bundled module, not a Lambda layer**
+
+esbuild bundles `shared/` into every function zip. Chosen over a layer
+because: one artifact per function (no layer-version coordination between
+code and infra applies), esbuild tree-shakes unused shared code, cold starts
+are identical, and zips stay tiny (~7KB). Revisit only if a port needs a
+large native dependency. `@aws-sdk/*` is never bundled — nodejs22.x ships
+SDK v3 in the runtime.
+
+Platform-level differences from the Vercel originals (every port inherits
+these; do not re-add them per endpoint):
+
+- **No in-memory rate limiting.** The `checkRateLimit` Map in `api/_guard.js`
+  relies on warm-instance reuse that Lambda doesn't guarantee. Baseline
+  protection is API Gateway stage throttling (`infra/modules/api`
+  `throttling_*` vars); per-user usage plans are the Phase 8 follow-up.
+- **`CAMBREE_ENV=prod` replaces `VERCEL_ENV=production`** for fail-closed
+  behavior (set by Terraform on every function).
+- **Supabase over REST/pooler only** (plan §6): Lambdas must use the
+  PostgREST API (as `shared/usage.js` does) or the Supavisor pooler — never a
+  direct Postgres connection.
+
+**Keep `shared/guard.js` in sync with `api/_guard.js`** (origin allowlist,
+CORS headers, JWT semantics) until Vercel is decommissioned. The
+`api-aws-tests` workflow triggers on changes to either copy.
+
+## Secrets (the one manual step per environment)
+
+Terraform creates the per-env Secrets Manager **container only** —
+`cambree/<env>/api-env` — with no value, so secret values never exist in git
+or Terraform state. After the first apply in an env, set the value **once**:
+
+```sh
+# Write the JSON locally (never commit it), e.g. secrets.json:
+# { "SUPABASE_SERVICE_KEY": "...", "SUPABASE_JWT_SECRET": "...", "ANTHROPIC_API_KEY": "..." }
+aws secretsmanager put-secret-value \
+  --secret-id cambree/<env>/api-env \
+  --secret-string file://secrets.json
+rm secrets.json
+```
+
+Copy values from the Vercel project's env vars for the matching environment.
+Include only keys an AWS endpoint actually reads (the pilot needs
+`SUPABASE_SERVICE_KEY`); add keys as later ports need them by running
+`put-secret-value` again with the full updated JSON. Note: secrets are cached
+per Lambda instance for its lifetime, so an updated value only reaches
+instances started after the change — redeploy the function (or wait for
+instance recycling) to force a refresh.
+
+Every Lambda receives the container's ARN as `SECRETS_ARN`; `shared/secrets.js`
+fetches it on cold start and merges keys into `process.env` (Terraform-set
+plaintext env vars win over secret keys).
+
+## Build & deploy
+
+- CI (`.github/workflows/terraform.yml`) runs `npm ci && npm run build` here
+  before every `terraform plan`/`apply`; `archive_file` zips `dist/<name>/`
+  so a code-only merge redeploys through the same pipeline (changed
+  `source_code_hash`).
+- Local check: `cd api-aws && npm ci && npm run build`.
+- Unit tests: `npm run test:apiaws` from the repo root (no network, no AWS —
+  Supabase JWKS/REST are mocked in `tests/api-aws/`).
+
+## Port recipe (per endpoint — the mechanical checklist)
+
+1. **Create `api-aws/<name>/index.js`.** Copy the handler body from
+   `api/<name>.js` verbatim; import `applyCors`/`isAllowedOrigin`/`verifyJwt`
+   from `../shared/guard.js`, usage logging from `../shared/usage.js`, and
+   wrap with `httpAdapter` from `../shared/adapter.js`:
+   `export const handler = httpAdapter(yourHandler);`
+   Call `await loadSecrets()` first if the endpoint reads any secret env var.
+   Delete `checkRateLimit` calls (platform difference above). `await` any
+   write you care about — Lambda freezes on return, so fire-and-forget dies.
+2. **Await-audit.** Anything the Vercel copy left dangling
+   (`.catch(() => {})` fire-and-forget) must either be awaited or accepted as
+   lost on freeze.
+3. **Secrets.** If the endpoint needs a new secret key, add it to the JSON in
+   `cambree/<env>/api-env` in each env (manual step above). Plaintext config
+   goes in `common_environment` / the endpoint's `environment` map in
+   `infra/envs/*/api.tf`.
+4. **Terraform.** Add the endpoint key to the `endpoints` map in
+   `infra/envs/{dev,staging,prod}/api.tf` (override `timeout_seconds` /
+   `memory_mb` if the defaults 10s/256MB don't fit).
+5. **Tests.** Add `tests/api-aws/<name>.test.js` mirroring
+   `contact.test.js`: drive the real `handler` with APIGW v2 events, mock
+   every external service via a `globalThis.fetch` stub, and assert status
+   codes + response bodies **byte-identical to the Vercel copy** (that's the
+   parity oracle). Add the file to the `test:apiaws` script if you create a
+   new test file, and the Vercel original's path to
+   `.github/workflows/api-aws-tests.yml` trigger paths.
+6. **Merge through dev.** The terraform workflow plans on the PR and applies
+   on merge; verify with the curl matrix (disallowed origin → 403, preflight
+   → 204 + ACAO, oversized body → 400, happy path) against
+   `<api_endpoint output>/api/<name>`, and diff responses against the Vercel
+   endpoint for identical inputs.
+7. **Point the SPA at it.** Set the env's Amplify build var
+   `VITE_API_ENDPOINT_ORIGINS` (in `infra/envs/<env>/amplify.auto.tfvars`) to
+   include `{"/api/<name>": "<api_endpoint output>"}`. Amplify does not
+   rebuild on env-var changes — trigger a release. Vercel-served deploys keep
+   using the Vercel endpoint (the var is unset there) until cutover.
+8. **Promote** dev → staging → main. The Vercel copy stays deployed but
+   unreferenced; it is removed in the final conversion issue.

--- a/api-aws/build.mjs
+++ b/api-aws/build.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/* global process */
+// api-aws/build.mjs — bundles every endpoint directory into dist/<name>/index.mjs
+// (issue #86). Run by CI (.github/workflows/terraform.yml) before terraform
+// plan/apply; Terraform zips dist/<name>/ via archive_file.
+//
+// Each subdirectory of api-aws/ containing index.js is an endpoint. shared/
+// is bundled INTO each output (decision: bundled module, not a Lambda layer —
+// api-aws/README.md). @aws-sdk/* stays external: nodejs22.x ships SDK v3.
+
+import { build } from "esbuild";
+import { readdirSync, existsSync, rmSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const endpoints = readdirSync(root, { withFileTypes: true })
+  .filter((d) => d.isDirectory() && !["shared", "dist", "node_modules"].includes(d.name))
+  .filter((d) => existsSync(join(root, d.name, "index.js")))
+  .map((d) => d.name);
+
+if (!endpoints.length) {
+  console.error("no endpoint directories found");
+  process.exit(1);
+}
+
+rmSync(join(root, "dist"), { recursive: true, force: true });
+
+for (const name of endpoints) {
+  await build({
+    entryPoints: [join(root, name, "index.js")],
+    outfile: join(root, "dist", name, "index.mjs"),
+    bundle: true,
+    platform: "node",
+    target: "node22",
+    format: "esm",
+    external: ["@aws-sdk/*"],
+    sourcemap: false,
+    minify: false, // readable stack traces in CloudWatch beat a few KB
+    // ESM output needs an import-based require shim for any CJS dep esbuild
+    // pulls in (none today; harmless to keep).
+    banner: { js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);" },
+  });
+  console.log(`built dist/${name}/index.mjs`);
+}

--- a/api-aws/contact/index.js
+++ b/api-aws/contact/index.js
@@ -1,0 +1,65 @@
+// api-aws/contact/index.js
+//
+// Pilot AWS port of api/contact.js (issue #86) — enterprise/invoice inquiry
+// form. Logic is a line-for-line copy of the Vercel handler wrapped in the
+// shared adapter; keep the two in sync until the Vercel copy is removed in
+// the final conversion issue. Response parity is asserted by
+// tests/api-aws/contact.test.js against a mocked Supabase REST API.
+//
+// Differences from the Vercel copy (both platform-level, see shared/guard.js):
+//   - no in-memory checkRateLimit — API Gateway stage throttling covers spam
+//   - SUPABASE_SERVICE_KEY arrives via Secrets Manager at cold start
+
+import { httpAdapter } from "../shared/adapter.js";
+import { applyCors, isAllowedOrigin } from "../shared/guard.js";
+import { logUsageRow } from "../shared/usage.js";
+import { loadSecrets } from "../shared/secrets.js";
+
+// Basic email format validation
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function contactHandler(req, res) {
+  await loadSecrets(); // populates SUPABASE_SERVICE_KEY on cold start
+  if (applyCors(req, res)) return; // CORS preflight (issue #83)
+  if (req.method !== "POST") return res.status(405).end();
+
+  const origin = req.headers.origin || req.headers.referer || "";
+  if (!isAllowedOrigin(origin)) return res.status(403).json({ error: "Origin not allowed" });
+
+  const { name, email, company, interest, message } = req.body || {};
+  if (!name || !email || !company) return res.status(400).json({ error: "Name, email, and company are required" });
+  if (!EMAIL_RE.test(email)) return res.status(400).json({ error: "Invalid email format" });
+  // Cap field lengths to prevent abuse
+  if (name.length > 200 || email.length > 254 || company.length > 200 || (message && message.length > 5000)) {
+    return res.status(400).json({ error: "Input too long" });
+  }
+
+  const interestLabels = {
+    enterprise: "Enterprise pricing",
+    invoice: "Invoice / PO for procurement",
+    security: "Security & compliance documentation",
+    demo: "Product demo",
+    other: "Other inquiry",
+  };
+  const interestLabel = interestLabels[interest] || interest || "General inquiry";
+  const timestamp = new Date().toISOString();
+
+  // Log the inquiry to api_usage_log for admin visibility. Awaited (not
+  // fire-and-forget) because Lambda may freeze the instance the moment the
+  // response returns — a pending fetch would silently die.
+  await logUsageRow({
+    user_id: "contact-form",
+    model: "enterprise-inquiry",
+    input_tokens: 0,
+    output_tokens: 0,
+    web_searches: 0,
+    endpoint: JSON.stringify({ name, email, company, interest: interestLabel, message: message || "", timestamp }),
+  }, { wait: true });
+
+  res.json({
+    ok: true,
+    message: `Thanks, ${name}! We've received your inquiry about ${interestLabel.toLowerCase()} for ${company}. We'll be in touch within 1 business day at ${email}.`,
+  });
+}
+
+export const handler = httpAdapter(contactHandler);

--- a/api-aws/package-lock.json
+++ b/api-aws/package-lock.json
@@ -1,0 +1,499 @@
+{
+  "name": "cambree-api-aws",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cambree-api-aws",
+      "version": "0.0.0",
+      "devDependencies": {
+        "esbuild": "^0.25.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    }
+  }
+}

--- a/api-aws/package.json
+++ b/api-aws/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cambree-api-aws",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "AWS Lambda sources for the API platform (issue #86). Vercel's api/ stays live and untouched; endpoints move here one at a time.",
+  "scripts": {
+    "build": "node build.mjs"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.0"
+  }
+}

--- a/api-aws/shared/adapter.js
+++ b/api-aws/shared/adapter.js
@@ -1,0 +1,71 @@
+// api-aws/shared/adapter.js
+/* global Buffer */
+//
+// Thin translation between API Gateway HTTP API (payload v2.0) events and the
+// Vercel-style (req, res) handler shape the existing api/ functions use.
+// Written once here so every endpoint port is a near-copy of its Vercel
+// source — the port recipe in api-aws/README.md depends on this staying thin.
+//
+// Deliberately NOT covered (add only when an endpoint needs it):
+//   - streaming responses (claude-stream stays on Vercel until Phase 4)
+//   - multipart bodies
+
+// Build a Vercel-like req from an APIGW v2 event. Header names arrive
+// lowercased from API Gateway, matching what the handlers already expect.
+export function eventToReq(event) {
+  const headers = event.headers || {};
+  const rawBody = event.isBase64Encoded
+    ? Buffer.from(event.body || "", "base64").toString("utf8")
+    : (event.body || "");
+  let body = rawBody;
+  const ct = headers["content-type"] || "";
+  if (rawBody && ct.includes("application/json")) {
+    try { body = JSON.parse(rawBody); } catch { body = undefined; }
+  }
+  return {
+    method: event.requestContext?.http?.method || "GET",
+    url: event.rawPath || "/",
+    headers,
+    body,
+    rawBody,
+    // Vercel handlers read the client IP off the socket as a last resort;
+    // API Gateway gives it to us authoritatively.
+    socket: { remoteAddress: event.requestContext?.http?.sourceIp || "" },
+  };
+}
+
+// A Vercel-like res that accumulates into an APIGW v2 response object.
+export function makeRes() {
+  const out = { statusCode: 200, headers: {}, body: "" };
+  let finished = false;
+  const res = {
+    _result: out,
+    _finished: () => finished,
+    setHeader(name, value) { out.headers[name] = String(value); return res; },
+    status(code) { out.statusCode = code; return res; },
+    json(obj) {
+      out.headers["Content-Type"] = "application/json";
+      out.body = JSON.stringify(obj);
+      finished = true;
+      return res;
+    },
+    send(text) { out.body = String(text ?? ""); finished = true; return res; },
+    end(text) { if (text != null) out.body = String(text); finished = true; return res; },
+  };
+  return res;
+}
+
+// Wraps a Vercel-style handler into an APIGW Lambda handler.
+export function httpAdapter(handler) {
+  return async (event) => {
+    const req = eventToReq(event);
+    const res = makeRes();
+    try {
+      await handler(req, res);
+    } catch (e) {
+      console.error("[adapter] handler threw:", e?.message || e);
+      if (!res._finished()) res.status(500).json({ error: "internal error" });
+    }
+    return res._result;
+  };
+}

--- a/api-aws/shared/guard.js
+++ b/api-aws/shared/guard.js
@@ -1,0 +1,216 @@
+// api-aws/shared/guard.js
+/* global process, Buffer */
+//
+// Shared request validation for the AWS Lambda endpoints — the port of
+// api/_guard.js (issue #86). Bundled into every function by esbuild
+// (decision record: api-aws/README.md — bundled module, not a Lambda layer).
+//
+// KEEP IN SYNC with api/_guard.js until the Vercel copy is decommissioned
+// (migration Phase 9): origin allowlist, CORS headers, and JWT semantics must
+// stay byte-identical so an endpoint behaves the same on either platform.
+//
+// Deliberate differences from api/_guard.js:
+//   - NO in-memory per-IP/per-user rate limiter: Lambda instances don't share
+//     memory the way warm Vercel instances do, so the Map-based limiter is
+//     meaningless here. Baseline throttling is API Gateway stage limits
+//     (infra/modules/api); per-user usage plans are the Phase 8 follow-up.
+//   - IS_PRODUCTION comes from CAMBREE_ENV=prod (set by Terraform), not
+//     VERCEL_ENV.
+//   - Config is read lazily (per call, cheap) so secrets fetched at cold
+//     start (shared/secrets.js) can populate process.env before first use.
+
+import { createHmac, timingSafeEqual, createVerify, createPublicKey } from "crypto";
+
+const isProduction = () => process.env.CAMBREE_ENV === "prod";
+
+// ── ORIGIN CHECK — identical allowlist to api/_guard.js ──────────────────
+export function isAllowedOrigin(origin) {
+  if (!origin) return !isProduction(); // Allow missing origin in dev only
+  let u;
+  try { u = new URL(origin); } catch { return false; }
+  const h = u.hostname;
+  if (h === "cambrian-playbook.vercel.app") return true;
+  if (/^cambrian-playbook[a-z0-9-]*\.vercel\.app$/.test(h)) return true;
+  if (h.includes("cambrian-playbook") && h.endsWith(".vercel.app")) return true;
+  if (h === "cambriancatalyst.ai" || h.endsWith(".cambriancatalyst.ai")) return true;
+  if (h === "cambree.ai" || h.endsWith(".cambree.ai")) return true;
+  if (h === "localhost" || h === "127.0.0.1") return true;
+  // Amplify default domains (issue #83) — exact per-app hostnames, never a
+  // wildcard on all of amplifyapp.com. App ids: docs/aws-migration-plan.md §7.
+  if (h === "dev.d1gtnd67v2ws7a.amplifyapp.com") return true;    // dev
+  if (h === "staging.d33ublf97u0bs6.amplifyapp.com") return true; // staging
+  if (h === "main.d1fuoohbeo8gqk.amplifyapp.com") return true;   // prod
+  return false;
+}
+
+// ── CORS — identical behavior to api/_guard.js applyCors (issue #83) ─────
+// Bearer-token CORS: echo the origin back ONLY when allowlisted (never *),
+// answer preflight fully. Returns true when the request was an OPTIONS
+// preflight and has been answered — the caller must return immediately.
+export function applyCors(req, res) {
+  const origin = req.headers.origin || "";
+  if (origin && isAllowedOrigin(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Vary", "Origin");
+  }
+  if (req.method === "OPTIONS") {
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    res.setHeader(
+      "Access-Control-Allow-Headers",
+      "Authorization, Content-Type, X-Billable-Run, X-Billable-Max, X-Brief-Type, X-Seller-Url, X-Target-Company"
+    );
+    res.setHeader("Access-Control-Max-Age", "86400");
+    res.status(204).end();
+    return true;
+  }
+  return false;
+}
+
+// ── JWT AUTH — port of api/_guard.js verifyJwt ───────────────────────────
+// HS256 via SUPABASE_JWT_SECRET; ES256/RS256 via the Supabase JWKS endpoint.
+// Fail-closed everywhere in production.
+
+function base64UrlDecode(str) {
+  return Buffer.from(str.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+}
+
+export function decodeJwtPayload(token) {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    return JSON.parse(base64UrlDecode(parts[1]).toString());
+  } catch { return null; }
+}
+
+let cachedJWKS = null;
+let jwksFetchedAt = 0;
+const JWKS_TTL = 300_000; // 5 minutes
+
+const supabaseUrl = () => process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || "";
+const supabaseRef = () => {
+  try { return new URL(supabaseUrl()).hostname.split(".")[0]; } catch { return ""; }
+};
+
+async function getJWKS() {
+  if (cachedJWKS && (Date.now() - jwksFetchedAt) < JWKS_TTL) return cachedJWKS;
+  const base = supabaseUrl();
+  if (!base) return null;
+  try {
+    const r = await fetch(`${base}/auth/v1/.well-known/jwks.json`, { signal: AbortSignal.timeout(3000) });
+    if (!r.ok) return cachedJWKS; // keep stale cache on failure
+    const data = await r.json();
+    cachedJWKS = data.keys || [];
+    jwksFetchedAt = Date.now();
+    return cachedJWKS;
+  } catch {
+    return cachedJWKS; // keep stale cache
+  }
+}
+
+async function verifyAsymmetricSignature(token, alg) {
+  const parts = token.split(".");
+  const header = JSON.parse(base64UrlDecode(parts[0]).toString());
+  const signedData = parts[0] + "." + parts[1];
+  const signature = base64UrlDecode(parts[2]);
+
+  const keys = await getJWKS();
+  if (!keys || !keys.length) {
+    console.error("[auth] JWKS unavailable — rejecting request");
+    return false;
+  }
+
+  for (const jwk of keys) {
+    try {
+      if (header.kid && jwk.kid && header.kid !== jwk.kid) continue;
+      const publicKey = createPublicKey({ key: jwk, format: "jwk" });
+      const verifier = createVerify("SHA256");
+      verifier.update(signedData);
+      const opts = alg === "ES256" ? { key: publicKey, dsaEncoding: "ieee-p1363" } : publicKey;
+      if (verifier.verify(opts, signature)) return true;
+    } catch { continue; }
+  }
+  return false;
+}
+
+async function verifyJwtSignature(token) {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return false;
+
+    const header = JSON.parse(base64UrlDecode(parts[0]).toString());
+    const alg = header?.alg;
+
+    if (alg === "HS256") {
+      const secret = process.env.SUPABASE_JWT_SECRET || "";
+      if (!secret) {
+        if (isProduction()) return false;
+        return true;
+      }
+      const expected = createHmac("sha256", secret)
+        .update(parts[0] + "." + parts[1])
+        .digest();
+      const actual = base64UrlDecode(parts[2]);
+      if (expected.length !== actual.length) return false;
+      return timingSafeEqual(expected, actual);
+    }
+
+    if (alg === "ES256" || alg === "RS256") {
+      return await verifyAsymmetricSignature(token, alg);
+    }
+
+    // Unknown algorithm — reject
+    return false;
+  } catch { return false; }
+}
+
+export async function verifyJwt(req) {
+  const authHeader = req.headers.authorization || "";
+  if (authHeader.startsWith("Bearer ")) {
+    const token = authHeader.slice(7);
+    if (token) {
+      if (!await verifyJwtSignature(token)) return false;
+      const payload = decodeJwtPayload(token);
+      if (!payload) return false;
+
+      const now = Math.floor(Date.now() / 1000);
+      if (payload.exp && payload.exp < now) return false;
+
+      const ref = supabaseRef();
+      if (!ref) return false;
+      if (payload.iss !== "supabase" && !payload.iss?.includes(ref)) return false;
+
+      req._isGuest = false;
+      return true;
+    }
+  }
+
+  // No valid JWT — guest mode is dev-only, exactly as on Vercel.
+  if (isProduction()) return false;
+  const guestFlag = (process.env.ALLOW_GUEST || "").replace(/^["']|["']$/g, "").replace(/\\n/g, "").trim().toLowerCase();
+  if (guestFlag === "true" || guestFlag === "1" || guestFlag === "yes") {
+    req._isGuest = true;
+    return true;
+  }
+
+  return false;
+}
+
+// ── INPUT SIZE CAP ───────────────────────────────────────────────────────
+// Same ceiling as api/_guard.js buildAnthropicBody's input check; exported
+// standalone so non-Anthropic endpoints can cap arbitrary JSON bodies.
+export const MAX_INPUT_BYTES = 250_000;
+export function withinInputCap(value, max = MAX_INPUT_BYTES) {
+  try { return JSON.stringify(value ?? "").length <= max; } catch { return false; }
+}
+
+// ── CLIENT IP ────────────────────────────────────────────────────────────
+// API Gateway's requestContext.http.sourceIp lands on req.socket.remoteAddress
+// via the adapter and is authoritative; header fallbacks keep parity with the
+// Vercel handlers for any code path that still reads them.
+export function clientIp(req) {
+  const xff = req.headers["x-forwarded-for"];
+  return req.socket?.remoteAddress
+    || (xff ? xff.split(",").pop().trim() : "")
+    || req.headers["x-real-ip"]
+    || "unknown";
+}

--- a/api-aws/shared/secrets.js
+++ b/api-aws/shared/secrets.js
@@ -1,0 +1,51 @@
+// api-aws/shared/secrets.js
+/* global process */
+//
+// Cold-start secret loading (issue #86). Terraform creates the per-env secret
+// CONTAINER only (cambree/<env>/api-env) — the value is set once, out of band,
+// via `aws secretsmanager put-secret-value` (see api-aws/README.md), so secret
+// values never exist in git or Terraform state.
+//
+// The secret value is a single JSON object mirroring the server-side Vercel
+// env vars, e.g. {"SUPABASE_SERVICE_KEY":"...","SUPABASE_JWT_SECRET":"..."}.
+// Lambdas receive the container's ARN as SECRETS_ARN; on first invocation we
+// fetch it, merge the keys into process.env (existing env vars win, so
+// Terraform-set plaintext config is never overridden), and cache for the
+// instance lifetime.
+//
+// The SDK client is a runtime-provided module (nodejs22.x bundles AWS SDK v3);
+// esbuild marks @aws-sdk/* external so it is never packaged. Imported
+// dynamically, and only when SECRETS_ARN is set, so local tests (no SDK
+// installed) can exercise handlers without it.
+
+let loaded = null; // Promise — concurrent cold-start invocations share one fetch
+
+export function loadSecrets() {
+  if (loaded) return loaded;
+  loaded = (async () => {
+    const arn = process.env.SECRETS_ARN;
+    if (!arn) {
+      console.warn("[secrets] SECRETS_ARN not set — running on plain env vars only");
+      return {};
+    }
+    const { SecretsManagerClient, GetSecretValueCommand } = await import("@aws-sdk/client-secrets-manager");
+    const client = new SecretsManagerClient({});
+    const out = await client.send(new GetSecretValueCommand({ SecretId: arn }));
+    let parsed = {};
+    try { parsed = JSON.parse(out.SecretString || "{}"); } catch {
+      console.error("[secrets] secret value is not valid JSON — ignoring");
+      return {};
+    }
+    for (const [k, v] of Object.entries(parsed)) {
+      if (process.env[k] === undefined && typeof v === "string") process.env[k] = v;
+    }
+    return parsed;
+  })().catch((e) => {
+    // Fail open to plain env vars: endpoints that don't need any secret
+    // (e.g. a health check) keep working; ones that do will error clearly.
+    console.error("[secrets] load failed:", e?.message || e);
+    loaded = null; // allow retry on next invocation
+    return {};
+  });
+  return loaded;
+}

--- a/api-aws/shared/usage.js
+++ b/api-aws/shared/usage.js
@@ -1,0 +1,60 @@
+// api-aws/shared/usage.js
+/* global process */
+//
+// Usage logging for the AWS Lambda endpoints — the port of api/_usage.js
+// (issue #86). Same api_usage_log table, same Supabase REST API path.
+// KEEP IN SYNC with api/_usage.js until the Vercel copy is decommissioned.
+//
+// Supabase access rule (docs/aws-migration-plan.md §6): Lambdas talk to
+// Supabase over the REST API (PostgREST) or the Supavisor pooler — NEVER a
+// direct Postgres connection; hundreds of concurrent Lambdas would exhaust
+// the connection pool.
+
+const supabaseUrl = () => process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || "";
+const serviceKey = () => process.env.SUPABASE_SERVICE_KEY || "";
+
+/** Insert one row into api_usage_log via Supabase REST. Fire-and-forget by
+ *  default; pass { wait: true } to await the write (use sparingly). */
+export function logUsageRow(row, { wait = false } = {}) {
+  const url = supabaseUrl();
+  const key = serviceKey();
+  if (!url || !key) {
+    console.warn("[usage] Supabase env missing — usage row dropped");
+    return Promise.resolve();
+  }
+  const p = fetch(`${url}/rest/v1/api_usage_log`, {
+    method: "POST",
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+      Prefer: "return=minimal",
+    },
+    body: JSON.stringify(row),
+  }).then((r) => {
+    if (!r.ok) console.warn("[usage] insert failed:", r.status);
+  }).catch((e) => {
+    console.warn("[usage] insert error:", e?.message || e);
+  });
+  return wait ? p : Promise.resolve();
+}
+
+/** Port of api/_usage.js logTokenUsage — same row shape, same defaults. */
+export function logTokenUsage({ userId, orgId, model, inputTokens, outputTokens, cacheReadTokens = 0, cacheCreationTokens = 0, webSearches = 0, endpoint = "claude", targetCompany = null, sellerUrl = null, briefType = null, durationMs = null }) {
+  const row = {
+    user_id: userId || null,
+    org_id: orgId || null,
+    model: model || "unknown",
+    input_tokens: inputTokens || 0,
+    output_tokens: outputTokens || 0,
+    cache_read_tokens: cacheReadTokens || 0,
+    cache_creation_tokens: cacheCreationTokens || 0,
+    web_searches: webSearches || 0,
+    endpoint,
+  };
+  if (targetCompany) row.target_company = targetCompany.slice(0, 200);
+  if (sellerUrl) row.seller_url = sellerUrl.slice(0, 200);
+  if (briefType) row.brief_type = briefType.slice(0, 50);
+  if (Number.isInteger(durationMs) && durationMs >= 0) row.duration_ms = durationMs;
+  return logUsageRow(row);
+}

--- a/docs/aws-migration-plan.md
+++ b/docs/aws-migration-plan.md
@@ -139,6 +139,14 @@ Deploy-role trust policies match `sub = repo:Cambree-AI@311088446/cambrian-playb
 
 Security headers live in `customHttp.yml` (repo root); rewrites in the module's `custom_rule`s. Git connection = Amplify GitHub App (org-installed) + `AMPLIFY_GITHUB_TOKEN` PAT at create time, followed by the console "Update required" connection migration per app. Ops notes: API-created branches never auto-run a first build (trigger one release); branch env-var changes don't rebuild (trigger a release to bake them).
 
+### API platform (created 2026-09-02, issue #86 — `infra/modules/api` + `api-aws/`)
+
+The Phase 3 landing zone for function ports: per env, an **API Gateway HTTP API** with one Lambda per endpoint (nodejs22.x/arm64, routes mirror Vercel at `/api/<name>`), CloudWatch logs, stage throttling (the platform replacement for `_guard.js`'s in-memory limiter; usage plans are Phase 8), and a Secrets Manager container `cambree/<env>/api-env` (Terraform creates the container only — the value is set once per env via `put-secret-value`, documented in api-aws/README.md, so secret values never touch git or state).
+
+- Lambda sources live in **`api-aws/`** (Vercel's `api/` stays live and untouched); `api-aws/shared/` is the ported guard/usage/adapter/secrets layer, **bundled** into each function by esbuild (decision record in api-aws/README.md — bundled module, not a Lambda layer). CI builds the bundles inside `.github/workflows/terraform.yml` before plan/apply, so a code-only merge redeploys via `source_code_hash`.
+- **Pilot endpoint: `contact`.** The SPA reaches migrated endpoints via the `VITE_API_ENDPOINT_ORIGINS` JSON map (per-endpoint origin override in `src/lib/api.js`, set per env in `infra/envs/*/amplify.auto.tfvars` from the `api_endpoint` output); unmapped endpoints keep using `VITE_API_URL`.
+- Unit tests: `npm run test:apiaws` + `.github/workflows/api-aws-tests.yml` (mocked JWKS/Supabase, parity-oracle against the Vercel copies). The **port recipe** for every subsequent endpoint is in api-aws/README.md.
+
 - **Modules (proposed):** `network` (VPC, subnets, endpoints), `ecr`, `ecs-worker` (cluster, task defs, autoscaling), `queue` (SQS + DLQ), `orchestration` (Step Functions, IAM roles), `api` (API Gateway REST + WebSocket APIs, Lambdas, DynamoDB connections table), `crons` (EventBridge Scheduler), `secrets` (Secrets Manager/SSM), `amplify` (the Amplify app, branch config, domain, headers/rewrites), `dns` (Route 53, ACM), `observability` (CloudWatch dashboards/alarms, log groups, cost alarms).
 - Amplify itself is created via Terraform (`aws_amplify_app`, `aws_amplify_branch`, `aws_amplify_domain_association`) so hosting config is code, not console.
 - Bedrock access (model-invocation IAM policies, inference profiles) is Terraform-managed.

--- a/infra/envs/dev/.terraform.lock.hcl
+++ b/infra/envs/dev/.terraform.lock.hcl
@@ -1,6 +1,27 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.4"
+  hashes = [
+    "h1:jdmKm+xl6ZcQrijxapnZ94RVuz/G4vk7hsIa1N0VT5Q=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"

--- a/infra/envs/dev/amplify.tf
+++ b/infra/envs/dev/amplify.tf
@@ -31,6 +31,12 @@ variable "vite_api_url" {
   default     = ""
 }
 
+variable "vite_api_endpoint_origins" {
+  description = "Per-endpoint origin overrides as a JSON object (issue #86), e.g. {\"/api/contact\":\"<api_endpoint output>\"}. Endpoints not listed keep using vite_api_url. Empty = no overrides."
+  type        = string
+  default     = ""
+}
+
 module "amplify" {
   source = "../../modules/amplify"
 
@@ -40,10 +46,11 @@ module "amplify" {
   github_access_token = var.amplify_github_token
 
   environment_variables = {
-    VITE_SUPABASE_URL      = var.vite_supabase_url
-    VITE_SUPABASE_ANON_KEY = var.vite_supabase_anon_key
-    VITE_APP_URL           = var.vite_app_url
-    VITE_API_URL           = var.vite_api_url
+    VITE_SUPABASE_URL         = var.vite_supabase_url
+    VITE_SUPABASE_ANON_KEY    = var.vite_supabase_anon_key
+    VITE_APP_URL              = var.vite_app_url
+    VITE_API_URL              = var.vite_api_url
+    VITE_API_ENDPOINT_ORIGINS = var.vite_api_endpoint_origins
   }
 }
 

--- a/infra/envs/dev/api.tf
+++ b/infra/envs/dev/api.tf
@@ -1,0 +1,30 @@
+# API platform - dev (issue #86): API Gateway HTTP API + Lambda endpoints.
+# Pilot endpoint: contact. CI builds api-aws/dist before plan/apply
+# (.github/workflows/terraform.yml).
+
+module "api" {
+  source = "../../modules/api"
+
+  env      = "dev"
+  dist_dir = "${path.module}/../../../api-aws/dist"
+
+  endpoints = {
+    contact = {}
+  }
+
+  common_environment = {
+    # Public by design (same value the SPA bundles); the service key comes
+    # from the Secrets Manager container, never from here.
+    SUPABASE_URL = var.vite_supabase_url
+  }
+}
+
+output "api_endpoint" {
+  description = "Invoke URL for the dev API Lambdas (endpoint-origin map value for the SPA)"
+  value       = module.api.api_endpoint
+}
+
+output "api_secret_name" {
+  description = "Secrets Manager container to fill once via put-secret-value (api-aws/README.md)"
+  value       = module.api.secret_name
+}

--- a/infra/envs/prod/.terraform.lock.hcl
+++ b/infra/envs/prod/.terraform.lock.hcl
@@ -1,6 +1,27 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.4"
+  hashes = [
+    "h1:jdmKm+xl6ZcQrijxapnZ94RVuz/G4vk7hsIa1N0VT5Q=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"

--- a/infra/envs/prod/amplify.tf
+++ b/infra/envs/prod/amplify.tf
@@ -31,6 +31,12 @@ variable "vite_api_url" {
   default     = ""
 }
 
+variable "vite_api_endpoint_origins" {
+  description = "Per-endpoint origin overrides as a JSON object (issue #86), e.g. {\"/api/contact\":\"<api_endpoint output>\"}. Endpoints not listed keep using vite_api_url. Empty = no overrides."
+  type        = string
+  default     = ""
+}
+
 module "amplify" {
   source = "../../modules/amplify"
 
@@ -40,10 +46,11 @@ module "amplify" {
   github_access_token = var.amplify_github_token
 
   environment_variables = {
-    VITE_SUPABASE_URL      = var.vite_supabase_url
-    VITE_SUPABASE_ANON_KEY = var.vite_supabase_anon_key
-    VITE_APP_URL           = var.vite_app_url
-    VITE_API_URL           = var.vite_api_url
+    VITE_SUPABASE_URL         = var.vite_supabase_url
+    VITE_SUPABASE_ANON_KEY    = var.vite_supabase_anon_key
+    VITE_APP_URL              = var.vite_app_url
+    VITE_API_URL              = var.vite_api_url
+    VITE_API_ENDPOINT_ORIGINS = var.vite_api_endpoint_origins
   }
 }
 

--- a/infra/envs/prod/api.tf
+++ b/infra/envs/prod/api.tf
@@ -1,0 +1,31 @@
+# API platform - prod (issue #86): API Gateway HTTP API + Lambda endpoints.
+# Pilot endpoint: contact. CI builds api-aws/dist before plan/apply
+# (.github/workflows/terraform.yml); the apply is gated by the production
+# GitHub Environment's required-reviewer approval like every prod change.
+
+module "api" {
+  source = "../../modules/api"
+
+  env      = "prod"
+  dist_dir = "${path.module}/../../../api-aws/dist"
+
+  endpoints = {
+    contact = {}
+  }
+
+  common_environment = {
+    # Public by design (same value the SPA bundles); the service key comes
+    # from the Secrets Manager container, never from here.
+    SUPABASE_URL = var.vite_supabase_url
+  }
+}
+
+output "api_endpoint" {
+  description = "Invoke URL for the prod API Lambdas (endpoint-origin map value for the SPA)"
+  value       = module.api.api_endpoint
+}
+
+output "api_secret_name" {
+  description = "Secrets Manager container to fill once via put-secret-value (api-aws/README.md)"
+  value       = module.api.secret_name
+}

--- a/infra/envs/staging/.terraform.lock.hcl
+++ b/infra/envs/staging/.terraform.lock.hcl
@@ -1,6 +1,27 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.4"
+  hashes = [
+    "h1:jdmKm+xl6ZcQrijxapnZ94RVuz/G4vk7hsIa1N0VT5Q=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"

--- a/infra/envs/staging/amplify.tf
+++ b/infra/envs/staging/amplify.tf
@@ -31,6 +31,12 @@ variable "vite_api_url" {
   default     = ""
 }
 
+variable "vite_api_endpoint_origins" {
+  description = "Per-endpoint origin overrides as a JSON object (issue #86), e.g. {\"/api/contact\":\"<api_endpoint output>\"}. Endpoints not listed keep using vite_api_url. Empty = no overrides."
+  type        = string
+  default     = ""
+}
+
 module "amplify" {
   source = "../../modules/amplify"
 
@@ -40,10 +46,11 @@ module "amplify" {
   github_access_token = var.amplify_github_token
 
   environment_variables = {
-    VITE_SUPABASE_URL      = var.vite_supabase_url
-    VITE_SUPABASE_ANON_KEY = var.vite_supabase_anon_key
-    VITE_APP_URL           = var.vite_app_url
-    VITE_API_URL           = var.vite_api_url
+    VITE_SUPABASE_URL         = var.vite_supabase_url
+    VITE_SUPABASE_ANON_KEY    = var.vite_supabase_anon_key
+    VITE_APP_URL              = var.vite_app_url
+    VITE_API_URL              = var.vite_api_url
+    VITE_API_ENDPOINT_ORIGINS = var.vite_api_endpoint_origins
   }
 }
 

--- a/infra/envs/staging/api.tf
+++ b/infra/envs/staging/api.tf
@@ -1,0 +1,30 @@
+# API platform - staging (issue #86): API Gateway HTTP API + Lambda endpoints.
+# Pilot endpoint: contact. CI builds api-aws/dist before plan/apply
+# (.github/workflows/terraform.yml).
+
+module "api" {
+  source = "../../modules/api"
+
+  env      = "staging"
+  dist_dir = "${path.module}/../../../api-aws/dist"
+
+  endpoints = {
+    contact = {}
+  }
+
+  common_environment = {
+    # Public by design (same value the SPA bundles); the service key comes
+    # from the Secrets Manager container, never from here.
+    SUPABASE_URL = var.vite_supabase_url
+  }
+}
+
+output "api_endpoint" {
+  description = "Invoke URL for the staging API Lambdas (endpoint-origin map value for the SPA)"
+  value       = module.api.api_endpoint
+}
+
+output "api_secret_name" {
+  description = "Secrets Manager container to fill once via put-secret-value (api-aws/README.md)"
+  value       = module.api.secret_name
+}

--- a/infra/modules/api/README.md
+++ b/infra/modules/api/README.md
@@ -1,0 +1,47 @@
+# infra/modules/api — API Gateway + Lambda platform (issue #86)
+
+The platform Vercel serverless functions port onto (migration Phase 3+,
+docs/aws-migration-plan.md §8). One instantiation per env in
+`infra/envs/*/api.tf`.
+
+## What it creates
+
+- **API Gateway HTTP API** (not REST — cheaper, simpler; auth is JWT-in-code
+  via `api-aws/shared/guard.js` to preserve `api/_guard.js` semantics, so no
+  API Gateway authorizer) with a `$default` auto-deploy stage.
+- **One Lambda per `endpoints` key** (nodejs22.x, arm64), routed at
+  `ANY /api/<name>` — method policy and CORS stay in handler code for parity
+  with Vercel routing. Code comes from `api-aws/dist/<name>/` (built by CI
+  before plan/apply; `archive_file` hashes it into the plan, so code-only
+  merges redeploy).
+- **CloudWatch log groups** (Lambda per-function + API access logs), retention
+  `log_retention_days` (default 30).
+- **Stage throttling** (`throttling_rate_limit`/`throttling_burst_limit`) —
+  the platform replacement for the Vercel in-memory per-IP limiter. Per-user
+  usage plans: Phase 8.
+- **Secrets Manager container** `cambree/<env>/api-env` — container only,
+  never a version: no secret value in git or state. Filled once per env via
+  `aws secretsmanager put-secret-value` (documented in api-aws/README.md).
+  Every Lambda gets `SECRETS_ARN` + `GetSecretValue` on exactly that ARN.
+- **Per-endpoint IAM roles**: basic execution + read on the env secret.
+
+## Inputs of note
+
+- `endpoints` — map keyed by endpoint name; keys must match `api-aws/<name>/`
+  directories. Optional per-endpoint `timeout_seconds` (10), `memory_mb`
+  (256), `environment` (plaintext only).
+- `common_environment` — plaintext env vars on every function. **Never put a
+  secret here — this map lands in Terraform state.** Secrets go in the
+  container.
+- `dist_dir` — path to `api-aws/dist`; plan fails if CI didn't build first.
+
+## Outputs
+
+`api_endpoint` (the invoke URL — feed it to the SPA's
+`VITE_API_ENDPOINT_ORIGINS` map), `secret_name`/`secret_arn`,
+`lambda_function_names`.
+
+## Adding an endpoint
+
+Follow the port recipe in **api-aws/README.md** — the Terraform half is just
+a new key in each env's `endpoints` map.

--- a/infra/modules/api/main.tf
+++ b/infra/modules/api/main.tf
@@ -1,0 +1,197 @@
+# infra/modules/api — issue #86. HTTP API (cheaper/simpler than REST; auth is
+# JWT-in-code via the shared guard to keep api/_guard.js semantics, NOT an
+# API Gateway authorizer), one Lambda per endpoint, per-env Secrets Manager
+# container, CloudWatch log groups. Routes mirror the Vercel paths
+# (/api/<name>) so the client's endpoint-origin swap is mechanical.
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4"
+    }
+  }
+}
+
+locals {
+  api_name = "${var.name_prefix}-${var.env}-api"
+  # Lambda names are computed up front so log groups can be created with
+  # retention BEFORE the function first writes to them.
+  fn_names = { for k, v in var.endpoints : k => "${local.api_name}-${k}" }
+}
+
+# ── Secrets container (issue #86 pattern) ────────────────────────────────
+# Terraform creates ONLY the container - deliberately no
+# aws_secretsmanager_secret_version, so no secret value ever exists in git
+# or in Terraform state. The value (a JSON object of server env vars) is set
+# once per env, out of band:
+#   aws secretsmanager put-secret-value --secret-id <name> --secret-string file://...
+# See api-aws/README.md for the documented step.
+resource "aws_secretsmanager_secret" "api_env" {
+  name        = "${var.name_prefix}/${var.env}/api-env"
+  description = "Server-side env vars for the ${var.env} API Lambdas (JSON object). Value set manually - never via Terraform."
+}
+
+# ── HTTP API ─────────────────────────────────────────────────────────────
+# No cors_configuration on purpose: CORS is answered by the shared guard in
+# code, byte-identical to the Vercel behavior from issue #83. API Gateway
+# CORS would answer preflights itself and drift from that contract.
+resource "aws_apigatewayv2_api" "http" {
+  name          = local.api_name
+  protocol_type = "HTTP"
+}
+
+resource "aws_cloudwatch_log_group" "api_access" {
+  name              = "/aws/apigateway/${local.api_name}"
+  retention_in_days = var.log_retention_days
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.http.id
+  name        = "$default"
+  auto_deploy = true
+
+  default_route_settings {
+    throttling_rate_limit  = var.throttling_rate_limit
+    throttling_burst_limit = var.throttling_burst_limit
+  }
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_access.arn
+    format = jsonencode({
+      requestId        = "$context.requestId"
+      ip               = "$context.identity.sourceIp"
+      requestTime      = "$context.requestTime"
+      httpMethod       = "$context.httpMethod"
+      path             = "$context.path"
+      status           = "$context.status"
+      responseLength   = "$context.responseLength"
+      integrationError = "$context.integration.error"
+    })
+  }
+}
+
+# ── Per-endpoint IAM ─────────────────────────────────────────────────────
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "endpoint" {
+  for_each = var.endpoints
+
+  name               = "${local.fn_names[each.key]}-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "basic_execution" {
+  for_each = var.endpoints
+
+  role       = aws_iam_role.endpoint[each.key].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy_document" "read_secret" {
+  statement {
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [aws_secretsmanager_secret.api_env.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "read_secret" {
+  for_each = var.endpoints
+
+  name   = "read-api-env-secret"
+  role   = aws_iam_role.endpoint[each.key].id
+  policy = data.aws_iam_policy_document.read_secret.json
+}
+
+# ── Lambdas ──────────────────────────────────────────────────────────────
+# CI builds api-aws/dist/<name>/index.mjs (esbuild); archive_file zips it at
+# plan time, so a code-only merge produces a changed source_code_hash and
+# redeploys through the same pipeline as infra changes.
+data "archive_file" "endpoint" {
+  for_each = var.endpoints
+
+  type        = "zip"
+  source_dir  = "${var.dist_dir}/${each.key}"
+  output_path = "${var.dist_dir}/${each.key}.zip"
+}
+
+resource "aws_cloudwatch_log_group" "endpoint" {
+  for_each = var.endpoints
+
+  name              = "/aws/lambda/${local.fn_names[each.key]}"
+  retention_in_days = var.log_retention_days
+}
+
+resource "aws_lambda_function" "endpoint" {
+  for_each = var.endpoints
+
+  function_name = local.fn_names[each.key]
+  role          = aws_iam_role.endpoint[each.key].arn
+
+  filename         = data.archive_file.endpoint[each.key].output_path
+  source_code_hash = data.archive_file.endpoint[each.key].output_base64sha256
+
+  runtime       = "nodejs22.x"
+  architectures = ["arm64"]
+  handler       = "index.handler"
+  timeout       = each.value.timeout_seconds
+  memory_size   = each.value.memory_mb
+
+  environment {
+    # Precedence note: shared/secrets.js merges the secret's keys into
+    # process.env WITHOUT overriding values set here.
+    variables = merge(
+      var.common_environment,
+      {
+        CAMBREE_ENV = var.env
+        SECRETS_ARN = aws_secretsmanager_secret.api_env.arn
+      },
+      each.value.environment,
+    )
+  }
+
+  depends_on = [aws_cloudwatch_log_group.endpoint]
+}
+
+# ── Routing ──────────────────────────────────────────────────────────────
+resource "aws_apigatewayv2_integration" "endpoint" {
+  for_each = var.endpoints
+
+  api_id                 = aws_apigatewayv2_api.http.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.endpoint[each.key].invoke_arn
+  payload_format_version = "2.0"
+}
+
+# ANY (not just POST): method policy (405s) and OPTIONS preflight stay in the
+# handler/guard code, matching Vercel routing behavior.
+resource "aws_apigatewayv2_route" "endpoint" {
+  for_each = var.endpoints
+
+  api_id    = aws_apigatewayv2_api.http.id
+  route_key = "ANY /api/${each.key}"
+  target    = "integrations/${aws_apigatewayv2_integration.endpoint[each.key].id}"
+}
+
+resource "aws_lambda_permission" "apigw" {
+  for_each = var.endpoints
+
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.endpoint[each.key].function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.http.execution_arn}/*/*"
+}

--- a/infra/modules/api/outputs.tf
+++ b/infra/modules/api/outputs.tf
@@ -1,0 +1,24 @@
+output "api_endpoint" {
+  description = "Invoke URL of the HTTP API (https://<id>.execute-api.<region>.amazonaws.com). Endpoints serve at <api_endpoint>/api/<name>."
+  value       = aws_apigatewayv2_api.http.api_endpoint
+}
+
+output "api_id" {
+  description = "API Gateway HTTP API id."
+  value       = aws_apigatewayv2_api.http.id
+}
+
+output "secret_name" {
+  description = "Secrets Manager container the Lambdas read at cold start. Set its value once via `aws secretsmanager put-secret-value` (api-aws/README.md)."
+  value       = aws_secretsmanager_secret.api_env.name
+}
+
+output "secret_arn" {
+  description = "ARN of the api-env secret container."
+  value       = aws_secretsmanager_secret.api_env.arn
+}
+
+output "lambda_function_names" {
+  description = "Deployed Lambda names by endpoint, for `aws logs tail`/console lookups."
+  value       = { for k, f in aws_lambda_function.endpoint : k => f.function_name }
+}

--- a/infra/modules/api/variables.tf
+++ b/infra/modules/api/variables.tf
@@ -1,0 +1,57 @@
+# infra/modules/api — API platform for the Vercel -> AWS function migration
+# (issue #86): API Gateway HTTP API + one Lambda per endpoint + Secrets
+# Manager container + CloudWatch logs. See README.md in this directory.
+
+variable "env" {
+  description = "Environment name (dev | staging | prod). Also exported to Lambdas as CAMBREE_ENV, which the shared guard uses for its production fail-closed behavior."
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.env)
+    error_message = "env must be one of: dev, staging, prod."
+  }
+}
+
+variable "name_prefix" {
+  description = "Prefix for resource names and the secret path."
+  type        = string
+  default     = "cambree"
+}
+
+variable "dist_dir" {
+  description = "Path to api-aws/dist, produced by `npm run build` in api-aws/ (CI does this before plan/apply). Each endpoint key must have a matching dist/<name>/ directory."
+  type        = string
+}
+
+variable "endpoints" {
+  description = "Endpoints to deploy, keyed by name; each becomes a Lambda routed at /api/<name>. Keys must match api-aws/<name>/ source directories."
+  type = map(object({
+    timeout_seconds = optional(number, 10)
+    memory_mb       = optional(number, 256)
+    environment     = optional(map(string), {})
+  }))
+}
+
+variable "common_environment" {
+  description = "Plaintext environment variables set on every Lambda (public config only - secrets go in the Secrets Manager container, never here: this map lands in state)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "throttling_rate_limit" {
+  description = "Steady-state requests/second across the stage (replaces the Vercel in-memory per-IP limiter as the baseline; per-user usage plans are the Phase 8 follow-up)."
+  type        = number
+  default     = 25
+}
+
+variable "throttling_burst_limit" {
+  description = "Burst capacity for the stage."
+  type        = number
+  default     = 100
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch retention for Lambda and API access logs."
+  type        = number
+  default     = 30
+}

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
     "test:properties": "node tests/fit-check/properties.js",
     "test:ssrf": "node tests/fetch-ssrf/ssrf.test.js",
     "test:icpstream": "node tests/icp-stream/stream.test.js && node tests/icp-stream/failure.test.js",
+    "test:apiaws": "node tests/api-aws/guard.test.js && node tests/api-aws/contact.test.js",
     "test:fitcheck": "npm run test:noop && npm run test:fitscores && npm run test:properties",
     "test:play": "node tests/the-play/eval.js",
     "test:regression": "node tests/fit-check/regression-sweep.js",
     "test:regression:full": "node tests/fit-check/regression-sweep.js --full",
-    "test": "npm run test:lint && npm run test:backtest && npm run test:icpstream && npm run test:golden"
+    "test": "npm run test:lint && npm run test:backtest && npm run test:icpstream && npm run test:apiaws && npm run test:golden"
   },
   "dependencies": {
     "fflate": "^0.8.2",

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -6,9 +6,26 @@
 // VITE_API_URL to the Vercel API origin until the functions migrate to AWS.
 export const API_BASE = import.meta.env.VITE_API_URL || "";
 
+// Per-endpoint origin overrides (issue #86) — the strangler mechanism for the
+// AWS migration. VITE_API_ENDPOINT_ORIGINS is a JSON object mapping an /api
+// path to the origin that serves it, e.g.
+//   {"/api/contact":"https://abc123.execute-api.us-east-2.amazonaws.com"}
+// Endpoints not in the map keep using API_BASE; malformed JSON disables all
+// overrides rather than breaking every API call.
+export const API_ENDPOINT_ORIGINS = (() => {
+  try { return JSON.parse(import.meta.env.VITE_API_ENDPOINT_ORIGINS || "{}") || {}; }
+  catch { console.warn("[api] VITE_API_ENDPOINT_ORIGINS is not valid JSON — ignoring"); return {}; }
+})();
+
 // Every client call to /api/* goes through this so the origin is switchable
-// per deployment (and later per endpoint, when functions move to AWS).
-export const apiFetch = (path, opts) => fetch(API_BASE + path, opts);
+// per deployment and per endpoint (issue #86) as functions move to AWS.
+export const apiFetch = (path, opts) => {
+  const route = path.split("?")[0];
+  const base = Object.prototype.hasOwnProperty.call(API_ENDPOINT_ORIGINS, route)
+    ? API_ENDPOINT_ORIGINS[route]
+    : API_BASE;
+  return fetch(base + path, opts);
+};
 
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 

--- a/tests/api-aws/contact.test.js
+++ b/tests/api-aws/contact.test.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/* global process */
+// tests/api-aws/contact.test.js — response-parity tests for the pilot AWS
+// port of /api/contact (issue #86). Drives the real Lambda handler (adapter
+// included) with APIGW v2 events; the Supabase REST API (a live service) is
+// mocked via a global fetch stub that records inserts — no network access.
+//
+// Parity oracle: the assertions mirror api/contact.js line for line (status
+// codes, error strings, success message shape, api_usage_log row shape), so
+// a drift between the two copies fails here.
+//
+// Usage: node tests/api-aws/contact.test.js   (exit 0 = green)
+
+process.env.CAMBREE_ENV = "prod";
+process.env.SUPABASE_URL = "https://mocked-project.supabase.co";
+process.env.SUPABASE_SERVICE_KEY = "mock-service-key";
+// SECRETS_ARN deliberately unset: loadSecrets() falls back to plain env vars,
+// so no AWS SDK call is attempted.
+
+const inserts = [];
+globalThis.fetch = async (url, init = {}) => {
+  if (String(url).includes("/rest/v1/api_usage_log")) {
+    inserts.push({ url: String(url), headers: init.headers, row: JSON.parse(init.body) });
+    return { ok: true, status: 201, json: async () => ({}) };
+  }
+  throw new Error(`unexpected fetch in contact tests: ${url}`);
+};
+
+const { handler } = await import("../../api-aws/contact/index.js");
+
+let passed = 0, failed = 0;
+const failures = [];
+function assert(cond, label) {
+  if (cond) { console.log(`  PASS  ${label}`); passed++; }
+  else { console.error(`  FAIL  ${label}`); failures.push(label); failed++; }
+}
+
+function event({ method = "POST", origin = "https://cambree.ai", body = null, headers = {} } = {}) {
+  return {
+    rawPath: "/api/contact",
+    headers: { "content-type": "application/json", ...(origin ? { origin } : {}), ...headers },
+    requestContext: { http: { method, sourceIp: "5.5.5.5" } },
+    body: body == null ? null : JSON.stringify(body),
+  };
+}
+
+const GOOD = { name: "Ada Lovelace", email: "ada@example.com", company: "Analytical Engines", interest: "enterprise", message: "Tell me more." };
+
+console.log("\n── happy path (parity with api/contact.js) ─────────────────────");
+{
+  const out = await handler(event({ body: GOOD }));
+  const body = JSON.parse(out.body);
+  assert(out.statusCode === 200, "200 on valid submission");
+  assert(body.ok === true, "ok: true");
+  assert(body.message === "Thanks, Ada Lovelace! We've received your inquiry about enterprise pricing for Analytical Engines. We'll be in touch within 1 business day at ada@example.com.",
+    "success message byte-identical to the Vercel handler");
+  assert(out.headers["Access-Control-Allow-Origin"] === "https://cambree.ai", "CORS echo on the POST response");
+  assert(inserts.length === 1, "exactly one api_usage_log insert");
+  const row = inserts[0].row;
+  assert(row.user_id === "contact-form" && row.model === "enterprise-inquiry", "row identity fields match Vercel handler");
+  const detail = JSON.parse(row.endpoint);
+  assert(detail.name === GOOD.name && detail.company === GOOD.company && detail.interest === "Enterprise pricing", "inquiry detail serialized into endpoint field");
+  assert(inserts[0].headers.apikey === "mock-service-key", "insert uses the service key (from env/secret)");
+}
+{
+  inserts.length = 0;
+  const out = await handler(event({ body: { ...GOOD, interest: "unlisted-topic" } }));
+  const detail = JSON.parse(inserts[0].row.endpoint);
+  assert(out.statusCode === 200 && detail.interest === "unlisted-topic", "unknown interest passes through as its own label");
+}
+
+console.log("\n── guard behavior ──────────────────────────────────────────────");
+{
+  const out = await handler(event({ method: "OPTIONS" }));
+  assert(out.statusCode === 204 && out.headers["Access-Control-Allow-Origin"] === "https://cambree.ai", "preflight answered with CORS headers");
+}
+{
+  const out = await handler(event({ method: "GET" }));
+  assert(out.statusCode === 405, "non-POST → 405");
+}
+{
+  const out = await handler(event({ origin: "https://evil.com", body: GOOD }));
+  assert(out.statusCode === 403 && JSON.parse(out.body).error === "Origin not allowed", "disallowed origin → 403 (same error string)");
+}
+
+console.log("\n── validation (same status + strings as Vercel) ────────────────");
+{
+  const out = await handler(event({ body: { email: "a@b.co", company: "X" } }));
+  assert(out.statusCode === 400 && JSON.parse(out.body).error === "Name, email, and company are required", "missing name → 400");
+}
+{
+  const out = await handler(event({ body: { ...GOOD, email: "not-an-email" } }));
+  assert(out.statusCode === 400 && JSON.parse(out.body).error === "Invalid email format", "bad email → 400");
+}
+{
+  const out = await handler(event({ body: { ...GOOD, message: "x".repeat(5001) } }));
+  assert(out.statusCode === 400 && JSON.parse(out.body).error === "Input too long", "oversized message → 400");
+}
+{
+  const out = await handler(event({ body: { ...GOOD, name: "x".repeat(201) } }));
+  assert(out.statusCode === 400 && JSON.parse(out.body).error === "Input too long", "oversized name → 400");
+}
+{
+  const out = await handler(event({ body: null }));
+  assert(out.statusCode === 400, "empty body → 400");
+}
+
+console.log("\n── resilience ──────────────────────────────────────────────────");
+{
+  // Supabase down: inquiry logging fails but the user still gets a response
+  // (logUsageRow catches; parity with the Vercel try/catch).
+  const prevFetch = globalThis.fetch;
+  globalThis.fetch = async () => { throw new Error("supabase down"); };
+  const out = await handler(event({ body: GOOD }));
+  assert(out.statusCode === 200 && JSON.parse(out.body).ok === true, "Supabase outage does not fail the submission");
+  globalThis.fetch = prevFetch;
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) { console.error("Failures:\n  " + failures.join("\n  ")); process.exit(1); }

--- a/tests/api-aws/guard.test.js
+++ b/tests/api-aws/guard.test.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/* global process */
+/* global Buffer */
+// tests/api-aws/guard.test.js — unit tests for the AWS shared guard layer
+// (issue #86): origin allow/deny, CORS preflight parity with api/_guard.js,
+// JWT verification (HS256 + ES256-via-JWKS, expired, garbage, wrong key),
+// input caps, adapter translation. The Supabase JWKS endpoint (a live
+// service) is mocked via a global fetch stub — no network access.
+//
+// Usage: node tests/api-aws/guard.test.js   (exit 0 = green)
+
+import { createHmac, generateKeyPairSync, createSign } from "crypto";
+import {
+  isAllowedOrigin, applyCors, verifyJwt, decodeJwtPayload,
+  withinInputCap, clientIp,
+} from "../../api-aws/shared/guard.js";
+import { eventToReq, makeRes, httpAdapter } from "../../api-aws/shared/adapter.js";
+
+let passed = 0, failed = 0;
+const failures = [];
+function assert(cond, label) {
+  if (cond) { console.log(`  PASS  ${label}`); passed++; }
+  else { console.error(`  FAIL  ${label}`); failures.push(label); failed++; }
+}
+
+// ── test fixtures ─────────────────────────────────────────────────────────
+const SUPABASE_URL = "https://akceiidofsiajrjtgone.supabase.co";
+const HS_SECRET = "test-jwt-secret-for-unit-tests-only";
+
+const b64url = (buf) => Buffer.from(buf).toString("base64url");
+function mintHS256({ exp = Math.floor(Date.now() / 1000) + 3600, iss = "supabase", secret = HS_SECRET, sub = "user-1" } = {}) {
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = b64url(JSON.stringify({ sub, exp, iss }));
+  const sig = createHmac("sha256", secret).update(`${header}.${payload}`).digest("base64url");
+  return `${header}.${payload}.${sig}`;
+}
+
+// ES256 keypair + JWKS served by the fetch mock below
+const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+const jwk = { ...publicKey.export({ format: "jwk" }), kid: "test-key-1", alg: "ES256", use: "sig" };
+function mintES256({ exp = Math.floor(Date.now() / 1000) + 3600, iss = "supabase", key = privateKey, sub = "user-2" } = {}) {
+  const header = b64url(JSON.stringify({ alg: "ES256", typ: "JWT", kid: "test-key-1" }));
+  const payload = b64url(JSON.stringify({ sub, exp, iss }));
+  const signer = createSign("SHA256");
+  signer.update(`${header}.${payload}`);
+  const sig = signer.sign({ key, dsaEncoding: "ieee-p1363" }).toString("base64url");
+  return `${header}.${payload}.${sig}`;
+}
+
+// Mock of the live Supabase JWKS endpoint (the only outbound call the guard
+// makes). Anything else is a test bug — fail loudly.
+const realFetch = globalThis.fetch;
+globalThis.fetch = async (url) => {
+  if (String(url).includes("/.well-known/jwks.json")) {
+    return { ok: true, json: async () => ({ keys: [jwk] }) };
+  }
+  throw new Error(`unexpected fetch in guard tests: ${url}`);
+};
+
+const req = (headers = {}, method = "POST") => ({ method, headers });
+
+console.log("\n── origin allowlist (parity with api/_guard.js) ────────────────");
+process.env.CAMBREE_ENV = "prod";
+{
+  const allowed = [
+    "https://cambree.ai", "https://www.cambree.ai", "https://staging.cambree.ai",
+    "https://cambriancatalyst.ai", "https://app.cambriancatalyst.ai",
+    "https://cambrian-playbook.vercel.app",
+    "https://cambrian-playbook-git-staging-x.vercel.app",
+    "https://dev.d1gtnd67v2ws7a.amplifyapp.com",
+    "https://staging.d33ublf97u0bs6.amplifyapp.com",
+    "https://main.d1fuoohbeo8gqk.amplifyapp.com",
+    "http://localhost:5173", "http://127.0.0.1:5173",
+  ];
+  for (const o of allowed) assert(isAllowedOrigin(o), `allows ${o}`);
+  const denied = [
+    "https://evil.com",
+    "https://cambree.ai.evil.com",
+    "https://notcambree.ai",
+    "https://anything.amplifyapp.com",          // wildcard amplify must NOT pass
+    "https://x.dev.d1gtnd67v2ws7a.amplifyapp.com.evil.com",
+    "not a url",
+  ];
+  for (const o of denied) assert(!isAllowedOrigin(o), `denies ${o}`);
+  assert(!isAllowedOrigin(""), "prod: denies missing origin");
+}
+process.env.CAMBREE_ENV = "dev";
+assert(isAllowedOrigin(""), "dev: allows missing origin (local tools)");
+
+console.log("\n── CORS preflight (parity with issue #83) ──────────────────────");
+{
+  const res = makeRes();
+  const handled = applyCors(req({ origin: "https://cambree.ai" }, "OPTIONS"), res);
+  assert(handled === true, "OPTIONS preflight is fully answered");
+  assert(res._result.statusCode === 204, "preflight → 204");
+  assert(res._result.headers["Access-Control-Allow-Origin"] === "https://cambree.ai", "echoes allowlisted origin (never *)");
+  assert(res._result.headers["Vary"] === "Origin", "Vary: Origin set");
+  assert(/Authorization/.test(res._result.headers["Access-Control-Allow-Headers"]), "allows Authorization header");
+  assert(res._result.headers["Access-Control-Max-Age"] === "86400", "max-age matches Vercel guard");
+}
+{
+  const res = makeRes();
+  applyCors(req({ origin: "https://evil.com" }, "OPTIONS"), res);
+  assert(res._result.headers["Access-Control-Allow-Origin"] === undefined, "disallowed origin gets no ACAO header");
+}
+{
+  const res = makeRes();
+  const handled = applyCors(req({ origin: "https://cambree.ai" }, "POST"), res);
+  assert(handled === false, "POST is not consumed by applyCors");
+  assert(res._result.headers["Access-Control-Allow-Origin"] === "https://cambree.ai", "POST still gets ACAO echo");
+}
+
+console.log("\n── JWT verification ────────────────────────────────────────────");
+process.env.CAMBREE_ENV = "prod";
+process.env.SUPABASE_URL = SUPABASE_URL;
+process.env.SUPABASE_JWT_SECRET = HS_SECRET;
+{
+  const r = req({ authorization: `Bearer ${mintHS256()}` });
+  assert(await verifyJwt(r) === true, "HS256: valid token accepted");
+  assert(r._isGuest === false, "HS256: authenticated user is not a guest");
+}
+assert(await verifyJwt(req({ authorization: `Bearer ${mintHS256({ exp: Math.floor(Date.now() / 1000) - 60 })}` })) === false, "HS256: expired token rejected");
+assert(await verifyJwt(req({ authorization: `Bearer ${mintHS256({ secret: "wrong-secret" })}` })) === false, "HS256: wrong signature rejected");
+assert(await verifyJwt(req({ authorization: `Bearer ${mintHS256({ iss: "https://other-project.supabase.co/auth/v1" })}` })) === false, "HS256: foreign issuer rejected");
+assert(await verifyJwt(req({ authorization: "Bearer garbage.token" })) === false, "garbage token rejected");
+assert(await verifyJwt(req({ authorization: "Bearer " })) === false, "empty bearer rejected");
+assert(await verifyJwt(req({})) === false, "prod: no auth header rejected (no guest mode)");
+{
+  // alg:none-style forgery — header claims an unknown alg
+  const forged = `${b64url(JSON.stringify({ alg: "none" }))}.${b64url(JSON.stringify({ sub: "x" }))}.`;
+  assert(await verifyJwt(req({ authorization: `Bearer ${forged}` })) === false, "unknown/none algorithm rejected");
+}
+{
+  const r = req({ authorization: `Bearer ${mintES256()}` });
+  assert(await verifyJwt(r) === true, "ES256: valid token verified against (mocked) JWKS");
+}
+{
+  const { privateKey: otherKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  assert(await verifyJwt(req({ authorization: `Bearer ${mintES256({ key: otherKey })}` })) === false, "ES256: token signed by a different key rejected");
+}
+{
+  process.env.CAMBREE_ENV = "dev";
+  process.env.ALLOW_GUEST = "true";
+  const r = req({});
+  assert(await verifyJwt(r) === true && r._isGuest === true, "dev + ALLOW_GUEST: guest mode works");
+  process.env.CAMBREE_ENV = "prod";
+  const r2 = req({});
+  assert(await verifyJwt(r2) === false, "prod: ALLOW_GUEST is ignored (fail closed)");
+  delete process.env.ALLOW_GUEST;
+}
+
+console.log("\n── input caps + client IP ──────────────────────────────────────");
+assert(withinInputCap({ msg: "hello" }), "small body within cap");
+assert(!withinInputCap({ msg: "x".repeat(260_000) }), "260KB body over the 250KB cap");
+assert(withinInputCap("x".repeat(10), 20) && !withinInputCap("x".repeat(30), 20), "custom cap respected");
+assert(clientIp({ headers: {}, socket: { remoteAddress: "9.9.9.9" } }) === "9.9.9.9", "sourceIp via adapter socket wins");
+assert(clientIp({ headers: { "x-forwarded-for": "1.1.1.1, 2.2.2.2" }, socket: {} }) === "2.2.2.2", "XFF fallback takes rightmost entry");
+assert(clientIp({ headers: {}, socket: {} }) === "unknown", "no signal → 'unknown'");
+
+console.log("\n── adapter translation ─────────────────────────────────────────");
+{
+  const event = {
+    rawPath: "/api/contact",
+    headers: { "content-type": "application/json", origin: "https://cambree.ai" },
+    requestContext: { http: { method: "POST", sourceIp: "3.3.3.3" } },
+    body: JSON.stringify({ a: 1 }),
+  };
+  const r = eventToReq(event);
+  assert(r.method === "POST" && r.url === "/api/contact", "method + path mapped");
+  assert(r.body?.a === 1, "JSON body parsed");
+  assert(r.socket.remoteAddress === "3.3.3.3", "sourceIp lands on socket.remoteAddress");
+}
+{
+  const event = {
+    rawPath: "/api/contact",
+    headers: { "content-type": "application/json" },
+    requestContext: { http: { method: "POST", sourceIp: "3.3.3.3" } },
+    body: Buffer.from(JSON.stringify({ b: 2 })).toString("base64"),
+    isBase64Encoded: true,
+  };
+  assert(eventToReq(event).body?.b === 2, "base64-encoded JSON body decoded and parsed");
+}
+{
+  const lambda = httpAdapter(async (rq, rs) => rs.status(201).json({ ok: true }));
+  const out = await lambda({ headers: {}, requestContext: { http: { method: "POST" } } });
+  assert(out.statusCode === 201 && JSON.parse(out.body).ok === true, "handler response round-trips to APIGW shape");
+  assert(out.headers["Content-Type"] === "application/json", "json() sets content type");
+}
+{
+  const lambda = httpAdapter(async () => { throw new Error("boom"); });
+  const out = await lambda({ headers: {}, requestContext: { http: { method: "POST" } } });
+  assert(out.statusCode === 500 && JSON.parse(out.body).error === "internal error", "thrown handler → clean 500");
+}
+{
+  assert(decodeJwtPayload(mintHS256({ sub: "abc" }))?.sub === "abc", "decodeJwtPayload reads sub");
+  assert(decodeJwtPayload("nope") === null, "decodeJwtPayload tolerates garbage");
+}
+
+globalThis.fetch = realFetch;
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) { console.error("Failures:\n  " + failures.join("\n  ")); process.exit(1); }


### PR DESCRIPTION
## Summary

Implements #86 — the API platform the Vercel functions port onto (migration Phase 3), proven end-to-end with the `contact` pilot. Strangler pattern throughout: **Vercel's `api/` stays live and untouched**; only Amplify builds can be pointed at AWS, per endpoint, when we choose.

## What's in here

**`api-aws/` — Lambda sources (commit 1)**
- `shared/guard.js`: port of `api/_guard.js` — origin allowlist, CORS byte-identical to #83, JWT (HS256 + JWKS ES256/RS256), input caps. The in-memory rate limiter is deliberately NOT ported (Lambda instances don't share memory usefully) — API Gateway stage throttling replaces it; per-user usage plans noted as the Phase 8 follow-up.
- `shared/usage.js` (Supabase REST only, never direct Postgres — plan §6), `shared/adapter.js` (APIGW payload-v2 ⇄ Vercel `(req,res)`, written once), `shared/secrets.js` (cold-start Secrets Manager load via `SECRETS_ARN`).
- `contact/index.js`: pilot port — line-for-line handler copy wrapped in the adapter; the usage insert is awaited (Lambda freeze kills fire-and-forget).
- **Decision record** (in `api-aws/README.md`): shared code is esbuild-**bundled** into each function, not a Lambda layer. `@aws-sdk/*` external (ships in nodejs22.x).
- Tests: `tests/api-aws/` — 75 assertions. Guard matrix (origin allow/deny incl. amplifyapp wildcard rejection, CORS preflight parity, JWT valid/expired/garbage/alg-none/wrong-key), adapter translation, and `contact` **response parity byte-identical to the Vercel copy** (the parity oracle). Supabase JWKS/REST mocked — zero network, zero spend. Wired as `npm run test:apiaws` + `.github/workflows/api-aws-tests.yml`, which also triggers on changes to `api/_guard.js` / `api/contact.js` to catch drift between the copies.

**Terraform (commit 2)**
- `infra/modules/api`: API Gateway **HTTP API** (JWT-in-code, no authorizer — preserves `_guard.js` semantics), one Lambda per `endpoints` key routed at `ANY /api/<name>` (paths mirror Vercel so the client swap is mechanical), CloudWatch log groups + API access logs, stage throttling defaults, per-endpoint IAM roles.
- Secrets: `cambree/<env>/api-env` created as a **container only** — no `secret_version` resource, so secret values never exist in git or Terraform state. Value set once per env via `put-secret-value` (documented).
- `infra/envs/{dev,staging,prod}/api.tf`: instantiated with the `contact` pilot; outputs `api_endpoint` + `api_secret_name`.
- `.github/workflows/terraform.yml`: `api-aws/**` added to trigger paths; both jobs build the Lambda bundles before `terraform init`, so `archive_file` hashes the real zip into the plan — **a code-only merge deploys code + infra together** through the existing plan/apply pipeline (prod still gated by required-reviewer approval).

**Client + docs (commit 3)**
- `src/lib/api.js`: `VITE_API_ENDPOINT_ORIGINS` — JSON path→origin map; endpoints not in the map keep using `VITE_API_URL`. Defaults empty everywhere, so **this PR changes no runtime behavior on any deploy**. Passed through the Amplify build env in all three `amplify.tf`.
- Port recipe for every subsequent endpoint (the batch issues): `api-aws/README.md`. Module docs: `infra/modules/api/README.md`. Plan §7 record + CLAUDE.md updates.

## Post-merge manual steps (by design — everything else is pipeline-automatic)

1. **Fill the secret once per env** after the first apply (value from the Vercel project env; never in git/state):
   `aws secretsmanager put-secret-value --secret-id cambree/<env>/api-env --secret-string '{"SUPABASE_SERVICE_KEY":"…"}'`
2. **Point the SPA at the new endpoint** (two-step apply, same pattern as `vite_app_url` in #82): set `vite_api_endpoint_origins = "{\"/api/contact\":\"<api_endpoint output>\"}"` in the env's `amplify.auto.tfvars`, merge, then trigger an Amplify release (env-var changes don't rebuild on their own).
3. **Verify**: curl matrix (403 bad origin / 204 preflight / 400 oversized / 200 happy path) diffed against the Vercel endpoint; one UI submission from the Amplify domain checked in CloudWatch.

## QA gate

- `npm run test:apiaws` — 75/75 green (mocked live services); `test:lint`, `test:backtest`, `test:icpstream` — 0 failures
- `npm run build` (SPA) — succeeds; `api-aws` bundle build — succeeds
- `terraform validate` — clean in dev, staging, prod; lock files gain `hashicorp/archive` (all-platform hashes)
- New JS lints clean; no scoring/brief-pipeline changes, so Stage-0 validation not triggered

Closes #86
