### PR TITLE
feature: point dev SPA /api/contact at API Gateway (#86)

### DIFF
--- a/infra/envs/dev/amplify.auto.tfvars
+++ b/infra/envs/dev/amplify.auto.tfvars
@@ -5,3 +5,8 @@ vite_supabase_url      = "https://akceiidofsiajrjtgone.supabase.co" # cambree-st
 vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFrY2VpaWRvZnNpYWpyanRnb25lIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODUyODE2OTgsImV4cCI6MjEwMDg1NzY5OH0.IFyk54T-pg1uWCEp3E1BO-kDHTIQXjgH23qImLYBehU"
 vite_app_url           = "https://dev.d1gtnd67v2ws7a.amplifyapp.com"
 vite_api_url           = "https://staging.cambree.ai" # Vercel staging serves /api there
+# Per-endpoint AWS overrides (issue #86, strangler): only the endpoints listed
+# here hit API Gateway; everything else stays on vite_api_url. Value from the
+# env's `api_endpoint` Terraform output. Amplify env-var changes don't rebuild
+# on their own - trigger a release after this applies.
+vite_api_endpoint_origins = "{\"/api/contact\":\"https://lcog1o2zs2.execute-api.us-east-2.amazonaws.com\"}"


### PR DESCRIPTION
## Summary

Recipe step 7 of #86 for the **dev** environment: bakes the per-endpoint origin map into the Amplify dev build so the SPA's `/api/contact` calls the (already live and verified) dev API Gateway endpoint. Every other endpoint keeps using `vite_api_url` (Vercel) — strangler pattern, no other behavior changes.

- `vite_api_endpoint_origins = {"/api/contact": "https://lcog1o2zs2.execute-api.us-east-2.amazonaws.com"}` — from the dev `api_endpoint` Terraform output.
- The dev platform behind it was verified 2026-09-03: curl matrix (preflight 204 + exact #83 CORS headers, 403 disallowed origin, 405 GET, 400 validation with Vercel-identical error strings), happy path 200 with parity message, CloudWatch clean (secret loaded, Supabase insert succeeded, ~2ms warm).

## Post-merge steps

1. The terraform workflow applies this to the dev Amplify app's branch env vars automatically.
2. **Manual:** trigger a release on the Amplify dev app (`d1gtnd67v2ws7a`) — branch env-var changes don't rebuild on their own.
3. Submit the contact form from https://dev.d1gtnd67v2ws7a.amplifyapp.com and confirm the request lands in the `cambree-dev-api-contact` CloudWatch log group (and NOT in Vercel's function logs).

Part of #86 (platform merged in #127/#128; staging/prod endpoint-origin flips are separate follow-ups once dev soaks).
