### PR TITLE
bugfix: allow API Gateway origins in Amplify CSP connect-src (#86)

### DIFF
--- a/api-aws/README.md
+++ b/api-aws/README.md
@@ -123,5 +123,9 @@ plaintext env vars win over secret keys).
    include `{"/api/<name>": "<api_endpoint output>"}`. Amplify does not
    rebuild on env-var changes — trigger a release. Vercel-served deploys keep
    using the Vercel endpoint (the var is unset there) until cutover.
+   **CSP prerequisite (one-time per env, not per endpoint):** the env's
+   `api_endpoint` origin must be in the `connect-src` list in `customHttp.yml`
+   — otherwise the browser blocks the call before it leaves the page
+   (dev + staging added 2026-09-03; prod still pending its first apply).
 8. **Promote** dev → staging → main. The Vercel copy stays deployed but
    unreferenced; it is removed in the final conversion issue.

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -4,6 +4,14 @@
 # Vercel API origins (staging.cambree.ai, www.cambree.ai, cambree.ai) so the
 # Amplify-hosted SPA can call the functions cross-origin until they move to
 # AWS (#86-#89).
+# Deviation 2 (issue #86): connect-src also allows the per-env API Gateway
+# origins for AWS-migrated endpoints (VITE_API_ENDPOINT_ORIGINS). Exact
+# hostnames, never a wildcard on execute-api. One file serves every branch,
+# so all envs' origins are listed; the API's own origin allowlist + CORS
+# still restricts who may actually call it. Add the prod origin here after
+# the first prod apply creates it (main merge).
+#   dev:     lcog1o2zs2.execute-api.us-east-2.amazonaws.com
+#   staging: mcvaccmuoj.execute-api.us-east-2.amazonaws.com
 customHeaders:
   - pattern: '**'
     headers:
@@ -20,4 +28,4 @@ customHeaders:
       - key: Permissions-Policy
         value: 'camera=(), microphone=(), geolocation=()'
       - key: Content-Security-Policy
-        value: "default-src 'self'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://api.anthropic.com https://api.hubapi.com https://vercel.live https://staging.cambree.ai https://www.cambree.ai https://cambree.ai; img-src 'self' data: https:; worker-src 'self' blob:; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+        value: "default-src 'self'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://api.anthropic.com https://api.hubapi.com https://vercel.live https://staging.cambree.ai https://www.cambree.ai https://cambree.ai https://lcog1o2zs2.execute-api.us-east-2.amazonaws.com https://mcvaccmuoj.execute-api.us-east-2.amazonaws.com; img-src 'self' data: https:; worker-src 'self' blob:; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"


### PR DESCRIPTION
## Summary

Fixes the dev contact-form failure found in #86 UI testing: the submission never reached API Gateway — the browser blocked it because `customHttp.yml`'s CSP `connect-src` allows the Vercel API origins but not the new per-env API Gateway origins (console: `Refused to connect ... violates the document's Content Security Policy`).

- Adds the **dev** (`lcog1o2zs2…`) and **staging** (`mcvaccmuoj…`) execute-api origins to `connect-src` — exact hostnames, no wildcard, matching the repo's origin philosophy. One `customHttp.yml` serves every branch, so both envs are listed; the API's own origin allowlist + CORS still restricts who can actually call it. Prod's origin gets added after its first apply creates it (main merge).
- Documents the CSP prerequisite in the port recipe (`api-aws/README.md` step 7) as a one-time-per-env step so later endpoint ports don't trip on this.

## Verification plan

Merging to `dev` pushes a commit → Amplify auto-builds dev → new headers deploy with that build (env vars are already correct, so no separate release trigger needed this time). Then: resubmit the contact form from https://dev.d1gtnd67v2ws7a.amplifyapp.com → expect the success message, and confirm the request in the `cambree-dev-api-contact` CloudWatch log group.

Part of #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq5ewicDKcgiRczJfUzfKJ
