### PR TITLE
feature: point staging SPA /api/contact at API Gateway (#86)

### DIFF
--- a/infra/envs/staging/amplify.auto.tfvars
+++ b/infra/envs/staging/amplify.auto.tfvars
@@ -5,3 +5,8 @@ vite_supabase_url      = "https://akceiidofsiajrjtgone.supabase.co" # cambree-st
 vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFrY2VpaWRvZnNpYWpyanRnb25lIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODUyODE2OTgsImV4cCI6MjEwMDg1NzY5OH0.IFyk54T-pg1uWCEp3E1BO-kDHTIQXjgH23qImLYBehU"
 vite_app_url           = "https://staging.d33ublf97u0bs6.amplifyapp.com" # interim; becomes https://staging.cambree.ai after the #84 domain flip
 vite_api_url           = "https://staging.cambree.ai" # Vercel staging serves /api there
+# Per-endpoint AWS overrides (issue #86, strangler): only the endpoints listed
+# here hit API Gateway; everything else stays on vite_api_url. Value from the
+# env's `api_endpoint` Terraform output. Amplify env-var changes don't rebuild
+# on their own - trigger a release after this applies.
+vite_api_endpoint_origins = "{\"/api/contact\":\"https://mcvaccmuoj.execute-api.us-east-2.amazonaws.com\"}"


### PR DESCRIPTION
## Summary

Staging counterpart of #129 — recipe step 7 of #86 for the **staging** environment: bakes the per-endpoint origin map into the Amplify staging build so the SPA's `/api/contact` calls the staging API Gateway endpoint (`mcvaccmuoj.execute-api.us-east-2.amazonaws.com`). Every other endpoint keeps using `vite_api_url` (Vercel) — strangler pattern, nothing else changes.

All prerequisites are already in place:
- Platform applied to the staging account (#128), curl-verifiable at the endpoint
- Secret `cambree/staging/api-env` filled (2026-09-03)
- CSP `connect-src` already includes the staging execute-api origin (#131)
- Dev has been running this exact flip successfully (UI submission verified end-to-end in CloudWatch: POST → 200, usage row written)

## Post-merge steps

1. The terraform workflow applies the branch env var automatically.
2. **Trigger a release on the Amplify staging app** (`d33ublf97u0bs6`) — the merge-triggered auto-build races the terraform apply (on dev the auto-build started 41s before the env var landed), so a release after the apply finishes is the reliable path.
3. Verify: submit the contact form from https://staging.d33ublf97u0bs6.amplifyapp.com and confirm the hit in the `cambree-staging-api-contact` CloudWatch log group.

Part of #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq5ewicDKcgiRczJfUzfKJ
