### PR TITLE
feature: prod /api/contact flip — CSP origin + endpoint-origin map (#86)

### DIFF
--- a/api-aws/README.md
+++ b/api-aws/README.md
@@ -126,6 +126,6 @@ plaintext env vars win over secret keys).
    **CSP prerequisite (one-time per env, not per endpoint):** the env's
    `api_endpoint` origin must be in the `connect-src` list in `customHttp.yml`
    — otherwise the browser blocks the call before it leaves the page
-   (dev + staging added 2026-09-03; prod still pending its first apply).
+   (all three envs added 2026-09-03).
 8. **Promote** dev → staging → main. The Vercel copy stays deployed but
    unreferenced; it is removed in the final conversion issue.

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -8,10 +8,10 @@
 # origins for AWS-migrated endpoints (VITE_API_ENDPOINT_ORIGINS). Exact
 # hostnames, never a wildcard on execute-api. One file serves every branch,
 # so all envs' origins are listed; the API's own origin allowlist + CORS
-# still restricts who may actually call it. Add the prod origin here after
-# the first prod apply creates it (main merge).
+# still restricts who may actually call it.
 #   dev:     lcog1o2zs2.execute-api.us-east-2.amazonaws.com
 #   staging: mcvaccmuoj.execute-api.us-east-2.amazonaws.com
+#   prod:    ndrgushglj.execute-api.us-east-2.amazonaws.com
 customHeaders:
   - pattern: '**'
     headers:
@@ -28,4 +28,4 @@ customHeaders:
       - key: Permissions-Policy
         value: 'camera=(), microphone=(), geolocation=()'
       - key: Content-Security-Policy
-        value: "default-src 'self'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://api.anthropic.com https://api.hubapi.com https://vercel.live https://staging.cambree.ai https://www.cambree.ai https://cambree.ai https://lcog1o2zs2.execute-api.us-east-2.amazonaws.com https://mcvaccmuoj.execute-api.us-east-2.amazonaws.com; img-src 'self' data: https:; worker-src 'self' blob:; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+        value: "default-src 'self'; script-src 'self' https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://api.anthropic.com https://api.hubapi.com https://vercel.live https://staging.cambree.ai https://www.cambree.ai https://cambree.ai https://lcog1o2zs2.execute-api.us-east-2.amazonaws.com https://mcvaccmuoj.execute-api.us-east-2.amazonaws.com https://ndrgushglj.execute-api.us-east-2.amazonaws.com; img-src 'self' data: https:; worker-src 'self' blob:; frame-src 'self' https://vercel.live; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"

--- a/infra/envs/prod/amplify.auto.tfvars
+++ b/infra/envs/prod/amplify.auto.tfvars
@@ -5,3 +5,8 @@ vite_supabase_url      = "https://xtnidawfuaxwwwcnkewu.supabase.co" # Cambrian P
 vite_supabase_anon_key = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inh0bmlkYXdmdWF4d3d3Y25rZXd1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzU3Njc2NzEsImV4cCI6MjA5MTM0MzY3MX0.JPTyCbsLk9Kr4AHo3ynszOo_SxvLA-XpT_5TzP8M71o"
 vite_app_url           = "https://cambree.ai" # the live production site; stays correct through the #85 cutover
 vite_api_url           = "https://www.cambree.ai" # Vercel prod /api; MUST switch before the #85 cutover (the vercel.app alias 307s to this domain today, unusable for CORS)
+# Per-endpoint AWS overrides (issue #86, strangler): only the endpoints listed
+# here hit API Gateway; everything else stays on vite_api_url. Value from the
+# env's `api_endpoint` Terraform output. Amplify env-var changes don't rebuild
+# on their own - trigger a release after this applies.
+vite_api_endpoint_origins = "{\"/api/contact\":\"https://ndrgushglj.execute-api.us-east-2.amazonaws.com\"}"


### PR DESCRIPTION
## Summary

Prod counterpart of #129 (dev) / #132 (staging) — the last env flip for #86, unblocked by the first prod apply (#133) which created the prod API (`ndrgushglj.execute-api.us-east-2.amazonaws.com`) and its secret container (filled 2026-09-03).

- **`customHttp.yml`**: adds the prod execute-api origin to CSP `connect-src` — the step the file's comment reserved for "after the first prod apply". All three envs are now listed.
- **`infra/envs/prod/amplify.auto.tfvars`**: `vite_api_endpoint_origins` points the prod Amplify build's `/api/contact` at API Gateway; everything else stays on `vite_api_url`.
- **Port recipe**: CSP prerequisite marked done for all three envs.

**No production-user impact**: the prod Amplify app (`main.d1fuoohbeo8gqk`) serves no real traffic until the #85 cutover, and `cambree.ai` on Vercel keeps using its own `/api/contact` regardless (the env var doesn't exist there).

The prod endpoint's guard was smoke-tested after the apply: preflight → 204 with CORS echo, disallowed origin → 403, and missing origin → 403 (confirming `CAMBREE_ENV=prod` fail-closed, stricter than dev/staging as designed).

## Post-merge (once this reaches `main`)

1. The prod terraform apply (required-reviewer gated) sets the Amplify branch env var.
2. Trigger a release on the prod Amplify app (the merge auto-build races the apply, as seen on dev and staging).
3. Verify from `main.d1fuoohbeo8gqk.amplifyapp.com`: submit the contact form, confirm the hit in `cambree-prod-api-contact` CloudWatch logs. That completes #86's acceptance criteria in all three envs.

Part of #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq5ewicDKcgiRczJfUzfKJ
