### PR TITLE
feat: promo plan — 10 free runs → $45/mo ×2 → graduate to starter (#137)

### DIFF
--- a/api/_provision.js
+++ b/api/_provision.js
@@ -113,9 +113,11 @@ export async function provisionTrialAccess({ email, name, company, invitedBy = "
   // _usage.js). The admitting promo code is stamped on the org — checkout
   // verifies run-pack eligibility against it (migration 034). Conditional so
   // non-promo callers (issue #3 admin approval) never touch the column.
+  // Promo-code signups get 10 free runs (vs. the default 3 for standard trial)
+  // so they can evaluate the product before the $45/mo promo subscription (issue #137).
   const orgName = (company || name || cleanEmail).trim();
   const created = await sbFetch("orgs", "POST",
-    promoCode ? { name: orgName, promo_code: promoCode } : { name: orgName });
+    promoCode ? { name: orgName, promo_code: promoCode, run_limit: 10 } : { name: orgName });
   const orgId = Array.isArray(created) ? created[0]?.id : created?.id;
   if (!orgId) {
     console.warn("[provision] Org creation failed:", JSON.stringify(created));

--- a/api/checkout.js
+++ b/api/checkout.js
@@ -15,12 +15,13 @@ const APP_URL = process.env.VITE_APP_URL || "https://www.cambriancatalyst.ai";
 const SB_URL = process.env.VITE_SUPABASE_URL;
 const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
 
-// Plan config — maps planId to run limits
+// Plan config — maps planId to run limits. Keep in sync with stripe-webhook.js.
 const PLAN_LIMITS = {
-  starter:    { run_limit: 25,   max_run_limit: 5 },
-  pro:        { run_limit: 100,  max_run_limit: 20 },
-  team:       { run_limit: 250,  max_run_limit: 50 },
-  enterprise: { run_limit: 1000, max_run_limit: 200 },
+  starter:       { run_limit: 25,   max_run_limit: 5 },
+  pro:           { run_limit: 100,  max_run_limit: 20 },
+  team:          { run_limit: 250,  max_run_limit: 50 },
+  enterprise:    { run_limit: 1000, max_run_limit: 200 },
+  promo_monthly: { run_limit: 20,   max_run_limit: 0 },  // issue #137: 2-month promo subscription
 };
 
 // One-time run pack for promo-code signups — runs added by the webhook via
@@ -58,11 +59,17 @@ export default async function handler(req, res) {
 
   const { priceId, planId: requestedPlanId } = req.body || {};
   const isPack = requestedPlanId === "promo_pack";
+  const isPromoMonthly = requestedPlanId === "promo_monthly";
   let planId, sessionPriceId;
   if (isPack) {
     sessionPriceId = process.env.STRIPE_PRICE_PROMO_PACK;
     if (!sessionPriceId) return res.status(500).json({ error: "Promo offer not configured" });
     planId = "promo_pack";
+  } else if (isPromoMonthly) {
+    // $45/mo promo subscription — 2 billing cycles before graduating to starter (issue #137).
+    sessionPriceId = process.env.STRIPE_PRICE_PROMO_MONTHLY;
+    if (!sessionPriceId) return res.status(500).json({ error: "Promo offer not configured" });
+    planId = "promo_monthly";
   } else {
     if (!priceId || typeof priceId !== "string") return res.status(400).json({ error: "priceId required" });
     planId = PRICE_TO_PLAN[priceId];
@@ -111,6 +118,25 @@ export default async function handler(req, res) {
     }
   }
 
+  // Promo monthly eligibility (issue #137): org must be on trial plan AND have a
+  // promo_code on record (stamped at provisioning). The $45/mo offer is only for
+  // promo-code signups in the free phase — not general-public self-serve.
+  // promo orgs (old one-time pack purchasers) proceed via the regular starter checkout.
+  if (isPromoMonthly) {
+    try {
+      if (!orgId) return res.status(403).json({ error: "This offer isn't available for your account" });
+      const orgRes = await fetch(`${SB_URL}/rest/v1/orgs?id=eq.${orgId}&select=promo_code,plan`, {
+        headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}` },
+      });
+      const org = (await orgRes.json())?.[0];
+      const eligible = org?.promo_code && org.plan === "trial";
+      if (!eligible) return res.status(403).json({ error: "This offer isn't available for your account" });
+    } catch (e) {
+      console.error("[checkout] Promo monthly eligibility check failed:", e.message);
+      return res.status(500).json({ error: "Eligibility check failed" });
+    }
+  }
+
   try {
     // Create Stripe Checkout session — one-time payment for the run pack,
     // subscription for everything else
@@ -129,6 +155,10 @@ export default async function handler(req, res) {
     if (isPack) {
       params.append("metadata[pack_runs]", String(PROMO_PACK_RUNS));
     } else {
+      // Subscription metadata — the webhook reads plan_id to apply org limits.
+      // For promo_monthly, the Stripe Subscription Schedule (created in the webhook
+      // after checkout completes) will overwrite plan_id to "starter" on graduation,
+      // which triggers the automatic upgrade via customer.subscription.updated (issue #137).
       params.append("subscription_data[metadata][user_id]", payload.sub);
       params.append("subscription_data[metadata][org_id]", orgId);
       params.append("subscription_data[metadata][plan_id]", planId);

--- a/api/cron-reset-tokens.js
+++ b/api/cron-reset-tokens.js
@@ -44,9 +44,11 @@ export default async function handler(req, res) {
     const rolloverData = await rolloverRes.json();
     const paidCount = rolloverData?.orgs_processed || 0;
 
-    // Step 1b: Reset max_run_count for paid orgs (Max Mode removed, but
-    // counter should not accumulate indefinitely month-over-month)
-    await fetch(`${SB_URL}/rest/v1/orgs?plan=eq.paid&max_run_count=gt.0`, {
+    // Step 1b: Reset max_run_count for paid and promo_monthly orgs (Max Mode
+    // removed, but counter should not accumulate indefinitely month-over-month).
+    // promo_monthly has max_run_limit=0 so this should always be a no-op for
+    // those orgs, but defensive resets are cheap.
+    await fetch(`${SB_URL}/rest/v1/orgs?plan=in.(paid,promo_monthly)&max_run_count=gt.0`, {
       method: "PATCH",
       headers: {
         apikey: SB_KEY,

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -19,12 +19,13 @@ const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
 const processedSessions = new Set();
 const DEDUP_MAX = 500;
 
-// Plan config — same as checkout.js
+// Plan config — same as checkout.js. Keep in sync.
 const PLAN_LIMITS = {
-  starter:    { run_limit: 25,   max_run_limit: 5 },
-  pro:        { run_limit: 100,  max_run_limit: 20 },
-  team:       { run_limit: 250,  max_run_limit: 50 },
-  enterprise: { run_limit: 1000, max_run_limit: 200 },
+  starter:       { run_limit: 25,   max_run_limit: 5 },
+  pro:           { run_limit: 100,  max_run_limit: 20 },
+  team:          { run_limit: 250,  max_run_limit: 50 },
+  enterprise:    { run_limit: 1000, max_run_limit: 200 },
+  promo_monthly: { run_limit: 20,   max_run_limit: 0 },  // issue #137: 2-month promo subscription
 };
 
 // One-time run pack (plan_id "promo_pack") — same as checkout.js
@@ -145,6 +146,120 @@ async function applyRunPack(orgId, session) {
   }
 }
 
+// Promo monthly plan activation (issue #137).
+// Sets the org to plan='promo_monthly' with 20 runs/month and kicks off a Stripe
+// Subscription Schedule that automatically graduates to the starter price after
+// 2 billing cycles — no cron or manual step needed for the upgrade.
+async function applyPromoMonthly(orgId, session) {
+  if (!orgId) return;
+  const subscriptionId = session.subscription || null;
+  const promoEnd = new Date(Date.now() + 60 * 24 * 3600 * 1000).toISOString(); // ~60 days
+
+  try {
+    await fetch(`${SB_URL}/rest/v1/orgs?id=eq.${orgId}`, {
+      method: "PATCH",
+      headers: {
+        apikey: SB_KEY,
+        Authorization: `Bearer ${SB_KEY}`,
+        "Content-Type": "application/json",
+        Prefer: "return=minimal",
+      },
+      body: JSON.stringify({
+        plan: "promo_monthly",
+        run_limit: 20,
+        max_run_limit: 0,
+        run_count: 0,
+        rollover_cap: 20,
+        stripe_subscription_id: subscriptionId,
+        promo_period_end: promoEnd,
+      }),
+    });
+    console.log(`[stripe] Promo monthly activated for org ${orgId}: 20 runs/mo, ends ~${promoEnd}`);
+  } catch (e) {
+    console.error("[stripe] Promo monthly org update failed:", e.message);
+    return; // Do not create schedule if org update failed
+  }
+
+  // Attach a Subscription Schedule: 2 iterations at promo price → starter price forever.
+  // When Stripe advances to the starter phase, customer.subscription.updated fires with
+  // sub.metadata.plan_id='starter' and the existing updateOrg handler graduates the org.
+  if (subscriptionId) {
+    await attachPromoSchedule(subscriptionId);
+  } else {
+    console.warn("[stripe] Promo monthly: no subscription ID in session — schedule not created");
+  }
+}
+
+// Create a Stripe Subscription Schedule that transitions from the promo price to
+// the starter price after 2 billing cycles. Phase 2 sets metadata.plan_id='starter'
+// on the subscription so the existing customer.subscription.updated webhook handler
+// can call updateOrg('starter') without any additional promo-specific logic.
+async function attachPromoSchedule(subscriptionId) {
+  const PROMO_PRICE = process.env.STRIPE_PRICE_PROMO_MONTHLY;
+  const STARTER_PRICE = process.env.STRIPE_PRICE_STARTER;
+  if (!PROMO_PRICE || !STARTER_PRICE) {
+    console.warn("[stripe] attachPromoSchedule: STRIPE_PRICE_PROMO_MONTHLY or STRIPE_PRICE_STARTER not set — schedule skipped");
+    return;
+  }
+
+  // Step 1: create a schedule from the existing subscription (current period → phase 1).
+  const createParams = new URLSearchParams();
+  createParams.append("from_subscription", subscriptionId);
+  let schedule;
+  try {
+    const createRes = await fetch("https://api.stripe.com/v1/subscription_schedules", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${STRIPE_SECRET}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: createParams.toString(),
+    });
+    schedule = await createRes.json();
+    if (schedule.error) {
+      console.error("[stripe] Schedule create failed:", schedule.error.message);
+      return;
+    }
+  } catch (e) {
+    console.error("[stripe] Schedule create network error:", e.message);
+    return;
+  }
+
+  // Step 2: update the schedule with explicit two-phase definition.
+  // Phase 0: promo price, 2 billing cycles total (the current period counts as cycle 1).
+  // Phase 1: starter price, indefinite. end_behavior=release keeps the subscription
+  // running at the starter price after the schedule completes — no cancellation.
+  // Phase 1's metadata overwrites sub.metadata.plan_id to 'starter', which triggers
+  // the existing updateOrg('starter') logic in customer.subscription.updated.
+  const updateParams = new URLSearchParams();
+  updateParams.append("phases[0][items][0][price]", PROMO_PRICE);
+  updateParams.append("phases[0][items][0][quantity]", "1");
+  updateParams.append("phases[0][iterations]", "2");
+  updateParams.append("phases[1][items][0][price]", STARTER_PRICE);
+  updateParams.append("phases[1][items][0][quantity]", "1");
+  updateParams.append("phases[1][metadata][plan_id]", "starter");
+  updateParams.append("end_behavior", "release");
+
+  try {
+    const updateRes = await fetch(`https://api.stripe.com/v1/subscription_schedules/${schedule.id}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${STRIPE_SECRET}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: updateParams.toString(),
+    });
+    const updated = await updateRes.json();
+    if (updated.error) {
+      console.error("[stripe] Schedule update failed:", updated.error.message, "— org will NOT auto-graduate; resolve manually in Stripe");
+    } else {
+      console.log(`[stripe] Promo schedule ${schedule.id} created for subscription ${subscriptionId} — graduates to starter after 2 cycles`);
+    }
+  } catch (e) {
+    console.error("[stripe] Schedule update network error:", e.message);
+  }
+}
+
 async function downgradeOrg(orgId) {
   if (!orgId) return;
 
@@ -213,6 +328,7 @@ export default async function handler(req, res) {
         }
         console.log(`[stripe] Checkout completed: user=${userId}, org=${orgId}, plan=${planId}`);
         if (planId === "promo_pack") await applyRunPack(orgId, session);
+        else if (planId === "promo_monthly") await applyPromoMonthly(orgId, session);
         else await updateOrg(orgId, planId);
         break;
       }

--- a/supabase/migrations/036_promo_monthly_plan.sql
+++ b/supabase/migrations/036_promo_monthly_plan.sql
@@ -1,0 +1,64 @@
+-- Migration 036: Promo monthly plan — 10 free → $45/mo × 2 months → starter (issue #137)
+--
+-- Adds the promo_monthly plan value, two columns for Stripe subscription tracking and
+-- UI display, and updates process_monthly_rollover so promo_monthly orgs receive the
+-- same rollover mechanics as paid orgs.
+--
+-- Run order: after 035. Additive and IF NOT EXISTS-safe (staging shares prod DB).
+-- Stripe setup required before first checkout: create a $45/mo recurring price in the
+-- Stripe dashboard and set STRIPE_PRICE_PROMO_MONTHLY in Vercel env vars.
+
+-- ── 1. Extend plan constraint ────────────────────────────────────────────────
+-- Add promo_monthly alongside the existing values. DROP+ADD is the only way to
+-- alter a CHECK constraint in Postgres (same pattern as migration 034).
+ALTER TABLE public.orgs DROP CONSTRAINT IF EXISTS orgs_plan_check;
+ALTER TABLE public.orgs ADD CONSTRAINT orgs_plan_check
+  CHECK (plan IN ('trial', 'paid', 'suspended', 'promo', 'promo_monthly'));
+
+-- ── 2. New columns ────────────────────────────────────────────────────────────
+-- The Stripe subscription ID, stored at checkout completion, is needed to:
+-- (a) verify the subscription schedule was attached correctly,
+-- (b) surface a "manage subscription" link in the UI (future), and
+-- (c) allow manual graduation if the Stripe schedule ever fails.
+ALTER TABLE public.orgs ADD COLUMN IF NOT EXISTS stripe_subscription_id text;
+
+-- Approximate end of the promo period — stored for UI display (e.g. "Your promo
+-- rate ends on Oct 3, 2026"). The actual graduation is driven by Stripe's
+-- subscription schedule; this column is informational only and is cleared on
+-- graduation via the stripe-webhook handler.
+ALTER TABLE public.orgs ADD COLUMN IF NOT EXISTS promo_period_end timestamptz;
+
+-- ── 3. Monthly rollover — include promo_monthly alongside paid ───────────────
+-- Migration 034 redefined this RPC to process only plan='paid'. Now extend it to
+-- also process plan='promo_monthly': same rollover mechanics, same caps.
+-- promo orgs (old one-time pack) are intentionally excluded — their run_count is
+-- monotonic by design (the pack is a one-time allotment, not a monthly renewal).
+CREATE OR REPLACE FUNCTION public.process_monthly_rollover()
+RETURNS jsonb AS $$
+DECLARE
+  v_org record;
+  v_count int := 0;
+BEGIN
+  FOR v_org IN
+    SELECT id, run_count, run_limit, rollover_runs, rollover_cap
+    FROM public.orgs
+    WHERE plan IN ('paid', 'promo_monthly')
+    FOR UPDATE
+  LOOP
+    DECLARE
+      v_total_available int := v_org.run_limit + v_org.rollover_runs;
+      v_unused int := GREATEST(0, v_total_available - v_org.run_count);
+      v_new_rollover int := LEAST(v_unused, v_org.rollover_cap);
+    BEGIN
+      UPDATE public.orgs
+      SET run_count = 0,
+          rollover_runs = v_new_rollover,
+          updated_at = now()
+      WHERE id = v_org.id;
+      v_count := v_count + 1;
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object('ok', true, 'orgs_processed', v_count);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
New promo acquisition funnel. Three phases with automatic Stripe-driven graduation — no cron, no manual step.

| Phase | Plan | Runs | Price | Mechanism |
|---|---|---|---|---|
| 1 — Free | `trial` | 10 | $0 | `_provision.js` sets `run_limit=10` at org creation for promo-code signups |
| 2 — Promo | `promo_monthly` | 20/mo | $45/mo | Stripe Checkout → `applyPromoMonthly()` → Subscription Schedule |
| 3 — Starter | `paid` (starter) | 25/mo | $99/mo | Schedule fires `customer.subscription.updated` with `plan_id=starter` → existing `updateOrg` handler |

Rollover (unused runs carry forward, capped at 1 month's allocation) applies to `promo_monthly` same as `paid`.

## Files changed

**`supabase/migrations/036_promo_monthly_plan.sql`** (new)
- `promo_monthly` added to `orgs_plan_check` constraint
- `stripe_subscription_id text` column (graduation tracking + future customer portal)
- `promo_period_end timestamptz` column (UI display)
- `process_monthly_rollover()` updated to `plan IN ('paid', 'promo_monthly')`

**`api/_provision.js`** (+2 lines)
- Promo-code org creation sets `run_limit: 10` (was: DB default 3)

**`api/checkout.js`** (+40 lines)
- `promo_monthly` added to `PLAN_LIMITS`
- `isPromoMonthly` branch: resolves `STRIPE_PRICE_PROMO_MONTHLY`, eligibility check (`plan='trial' AND promo_code IS NOT NULL`), subscription-mode checkout

**`api/stripe-webhook.js`** (+118 lines)
- `promo_monthly` added to `PLAN_LIMITS`
- `applyPromoMonthly(orgId, session)`: PATCH org, then call `attachPromoSchedule`
- `attachPromoSchedule(subscriptionId)`: creates Stripe Subscription Schedule (2-phase: promo → starter), Phase 2 metadata `plan_id=starter` triggers existing graduation handler
- Routing: `checkout.session.completed` now routes `promo_monthly` to `applyPromoMonthly`

**`api/cron-reset-tokens.js`** (+4 lines)
- `max_run_count` reset extended to `plan=in.(paid,promo_monthly)` (defensive)

## Stripe setup required before deploy
1. Create a $45/month recurring price in the Stripe dashboard (product: "Cambree Promo Monthly")
2. Set `STRIPE_PRICE_PROMO_MONTHLY={price_id}` in Vercel env vars — **all environments**

No `STRIPE_PRICE_PROMO_MONTHLY` → checkout returns 500 "Promo offer not configured". The schedule also requires `STRIPE_PRICE_STARTER` which is already set.

## How graduation works (no new webhook code needed)
The Subscription Schedule's Phase 2 sets `metadata.plan_id=starter` on the subscription when it activates. This fires `customer.subscription.updated` with `sub.metadata.plan_id === "starter"`. The existing handler calls `updateOrg(orgId, "starter")` → `plan='paid'`, `run_limit=25`, `rollover_cap=25`, `run_count=0`. The `promo_period_end` column is not cleared automatically (informational only; can be cleared manually or via a follow-up).

If `attachPromoSchedule` fails (network error, misconfigured prices), the org is still correctly set to `promo_monthly` with 20 runs. It just won't graduate automatically — the error is logged as `[stripe] Schedule update failed — org will NOT auto-graduate; resolve manually in Stripe`. Support can create the schedule manually in the Stripe dashboard.

## Test plan
- [ ] Promo-code signup → org provisioned with `run_limit=10`, `plan=trial`
- [ ] Checkout with `planId=promo_monthly` → org gets `plan=promo_monthly`, `run_limit=20`, `stripe_subscription_id` set, Stripe schedule created (2 phases visible in Stripe dashboard)
- [ ] Non-promo-code user attempting promo_monthly checkout → 403 "This offer isn't available for your account"
- [ ] Simulate schedule phase advance in Stripe test mode → `customer.subscription.updated` fires → org graduates to `plan=paid`, `run_limit=25`
- [ ] Monthly cron on staging → promo_monthly org gets rollover (not reset)
- [ ] Regular starter checkout unaffected

Fixes #137