### PR TITLE
fix: PDF export content clipping from fixed print footer (#139)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -686,8 +686,8 @@ input[type=text]::placeholder, input[type=email]::placeholder, textarea::placeho
 
 /* ── PRINT ───────────────────────────────────────────── */
 @media print {
-  @page { margin: 14mm 12mm 18mm 12mm; size: A4; }
-  body { background: #fff !important; font-size: 11px !important; line-height: 1.5 !important; color: #1a1a2e !important; }
+  @page { margin: 16mm 12mm 22mm 12mm; size: A4; }
+  body { background: #fff !important; font-size: 11px !important; line-height: 1.5 !important; color: #1a1a2e !important; padding-bottom: 20px !important; }
 
   /* ── HIDE: chrome, nav, interactive, loading ── */
   .header, .session-bar, .footer, .actions-row, .incall-header,
@@ -769,19 +769,19 @@ input[type=text]::placeholder, input[type=email]::placeholder, textarea::placeho
   a[href^="http"]::after { content: " (" attr(href) ")"; font-size: 8px; color: #999; word-break: break-all; }
   a[href^="http"] { color: #1B3A6B !important; text-decoration: underline !important; }
 
-  /* ── PRINT FOOTER — every page ── */
+  /* ── PRINT FOOTER — last page only ── */
+  /* position:fixed was clamped to bottom:0 of the content box by Chrome's
+     print engine, causing its background:#fff to cover the last 1-2 lines
+     of text on every page. Removing fixed positioning makes it flow as a
+     normal block at the end of the document (#139). */
   .print-footer {
     display: block !important;
-    position: fixed;
-    bottom: -12mm; /* sit inside the 18mm @page bottom margin, clear of body text */
-    left: 0;
-    right: 0;
+    margin-top: 20px;
+    padding: 8px 0 4px;
+    border-top: 1px solid #eee;
     text-align: center;
     font-size: 8px;
     color: #bbb;
-    padding: 6px 0;
-    border-top: 1px solid #eee;
-    background: #fff; /* opaque — never interleaves even if overlap recurs */
   }
   .print-footer .pf-brand { font-family: 'Crimson Pro', serif; font-weight: 700; color: #1a1a18; }
   .print-footer .pf-brand span { color: #8B6F47; }


### PR DESCRIPTION
## Problem

Each page of an exported brief PDF had its last 1–2 lines of text masked by a white band, making content appear cut off at the bottom.

## Root cause

`App.css` defined `.print-footer` with `position: fixed; bottom: -12mm; background: #fff`. The intent was to float the branding line into the 18 mm `@page` bottom margin. Chrome's print engine, however, clamps `position: fixed` elements to the content box (inside `@page` margins). `bottom: -12mm` is ignored — the footer ends up anchored at `bottom: 0` of the content area, and its opaque `background: #fff` covers the last ~20 px of body text on every printed page.

## Fix (`src/App.css` only)

| What | Before | After |
|------|--------|-------|
| `.print-footer` positioning | `position: fixed; bottom: -12mm; left: 0; right: 0; background: #fff` | Removed — flows as normal block at end of last page |
| `@page` top margin | 14 mm | 16 mm — more clearance for browser's native header line |
| `@page` bottom margin | 18 mm | 22 mm — more clearance for browser's native page-number line |
| `body` padding-bottom | (none) | 20 px — extra buffer above the physical bottom margin |

Trade-off: the Cambree branding footer now appears only on the last page rather than every page. This is acceptable for a brief export — the content being readable on every page takes priority.

## Test

1. Sign in on a paid plan → open any brief (Step 5)
2. Export → Export to PDF → Save as PDF in Chrome
3. Verify no white band at the bottom of any page; all text reads to the end of each column