### PR TITLE
release: promo monthly plan + game-plan merge + speed/scan-depth fixes

### DIFF
--- a/api/_guard.js
+++ b/api/_guard.js
@@ -311,6 +311,49 @@ function sanitizeSystemPrompt(system) {
   return SERVER_PREAMBLE + clean;
 }
 
+// ── PROMPT-CACHE BREAKPOINT (#27) ────────────────────────────────────────
+// Adds a cache_control breakpoint at the end of the last user message so the
+// full request prefix (tools → system → static instruction + schema body) is
+// cacheable. The brief pipeline's ~10k-token static prefix rides inside the
+// user message as a single text block, so a system-level breakpoint alone
+// never covers it — this is the breakpoint that makes identical re-runs and
+// the client retry ladder (which re-sends byte-identical bodies) hit cache.
+//
+// Cost/safety notes:
+// - Prompts below the model's minimum cacheable prefix (1024 tokens on
+//   Sonnet 4.6, 4096 on Haiku 4.5 / Opus 4.6) are silently NOT cached — no
+//   write premium, no behavior change.
+// - Cache reads/writes do not affect model output (temperature 0 + top_k 1
+//   determinism is preserved; rendered prompt bytes are unchanged — a single
+//   text block is API-equivalent to string content).
+// - Never mutates the client's message objects; returns a new array.
+function addMessagesCacheBreakpoint(messages) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg || msg.role !== "user") continue; // skip trailing assistant prefill ("{")
+    if (typeof msg.content === "string") {
+      if (!msg.content) return messages; // empty — leave for upstream validation
+      const marked = {
+        ...msg,
+        content: [{ type: "text", text: msg.content, cache_control: { type: "ephemeral" } }],
+      };
+      return messages.map((m, j) => (j === i ? marked : m));
+    }
+    if (Array.isArray(msg.content) && msg.content.length) {
+      const last = msg.content[msg.content.length - 1];
+      // Only mark a trailing text block; if the client already placed its own
+      // breakpoint, respect it (max 4 breakpoints per request).
+      if (!last || last.type !== "text" || last.cache_control) return messages;
+      const content = msg.content
+        .slice(0, -1)
+        .concat([{ ...last, cache_control: { type: "ephemeral" } }]);
+      return messages.map((m, j) => (j === i ? { ...m, content } : m));
+    }
+    return messages;
+  }
+  return messages;
+}
+
 // ── BODY BUILDER ─────────────────────────────────────────────────────────
 export function buildAnthropicBody(body, { stream = false } = {}) {
   if (!body || typeof body !== "object") {
@@ -338,11 +381,19 @@ export function buildAnthropicBody(body, { stream = false } = {}) {
     max_tokens: Math.min(Number(body.max_tokens) || 1024, MAX_TOKENS_CAP),
     temperature: 0,
     top_k: 1, // Deterministic: always pick the most likely token
-    messages: body.messages,
+    messages: addMessagesCacheBreakpoint(body.messages),
   };
   if (typeof body.system === "string" && body.system.length && body.system.length <= 30_000) {
-    // Plain string system — prepend SERVER_PREAMBLE and sanitize (existing behavior)
-    clean.system = sanitizeSystemPrompt(body.system);
+    // Plain string system — prepend SERVER_PREAMBLE and sanitize (existing
+    // behavior), emitted as a single cached block (#27). A one-element text
+    // block array renders byte-identically to the string form, so model input
+    // is unchanged; the cache_control breakpoint marks the end of the static
+    // anti-hallucination prefix so tools + system participate in the cache.
+    clean.system = [{
+      type: "text",
+      text: sanitizeSystemPrompt(body.system),
+      cache_control: { type: "ephemeral" },
+    }];
   } else if (Array.isArray(body.system) && body.system.length) {
     // Array of content blocks — used for prompt caching (cache_control: { type: "ephemeral" })
     // Sanitize each block's text through injection filter; SERVER_PREAMBLE is prepended as first block.

--- a/api/_provision.js
+++ b/api/_provision.js
@@ -113,9 +113,11 @@ export async function provisionTrialAccess({ email, name, company, invitedBy = "
   // _usage.js). The admitting promo code is stamped on the org — checkout
   // verifies run-pack eligibility against it (migration 034). Conditional so
   // non-promo callers (issue #3 admin approval) never touch the column.
+  // Promo-code signups get 10 free runs (vs. the default 3 for standard trial)
+  // so they can evaluate the product before the $45/mo promo subscription (issue #137).
   const orgName = (company || name || cleanEmail).trim();
   const created = await sbFetch("orgs", "POST",
-    promoCode ? { name: orgName, promo_code: promoCode } : { name: orgName });
+    promoCode ? { name: orgName, promo_code: promoCode, run_limit: 10 } : { name: orgName });
   const orgId = Array.isArray(created) ? created[0]?.id : created?.id;
   if (!orgId) {
     console.warn("[provision] Org creation failed:", JSON.stringify(created));

--- a/api/checkout.js
+++ b/api/checkout.js
@@ -15,12 +15,13 @@ const APP_URL = process.env.VITE_APP_URL || "https://www.cambriancatalyst.ai";
 const SB_URL = process.env.VITE_SUPABASE_URL;
 const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
 
-// Plan config — maps planId to run limits
+// Plan config — maps planId to run limits. Keep in sync with stripe-webhook.js.
 const PLAN_LIMITS = {
-  starter:    { run_limit: 25,   max_run_limit: 5 },
-  pro:        { run_limit: 100,  max_run_limit: 20 },
-  team:       { run_limit: 250,  max_run_limit: 50 },
-  enterprise: { run_limit: 1000, max_run_limit: 200 },
+  starter:       { run_limit: 25,   max_run_limit: 5 },
+  pro:           { run_limit: 100,  max_run_limit: 20 },
+  team:          { run_limit: 250,  max_run_limit: 50 },
+  enterprise:    { run_limit: 1000, max_run_limit: 200 },
+  promo_monthly: { run_limit: 20,   max_run_limit: 0 },  // issue #137: 2-month promo subscription
 };
 
 // One-time run pack for promo-code signups — runs added by the webhook via
@@ -58,11 +59,17 @@ export default async function handler(req, res) {
 
   const { priceId, planId: requestedPlanId } = req.body || {};
   const isPack = requestedPlanId === "promo_pack";
+  const isPromoMonthly = requestedPlanId === "promo_monthly";
   let planId, sessionPriceId;
   if (isPack) {
     sessionPriceId = process.env.STRIPE_PRICE_PROMO_PACK;
     if (!sessionPriceId) return res.status(500).json({ error: "Promo offer not configured" });
     planId = "promo_pack";
+  } else if (isPromoMonthly) {
+    // $45/mo promo subscription — 2 billing cycles before graduating to starter (issue #137).
+    sessionPriceId = process.env.STRIPE_PRICE_PROMO_MONTHLY;
+    if (!sessionPriceId) return res.status(500).json({ error: "Promo offer not configured" });
+    planId = "promo_monthly";
   } else {
     if (!priceId || typeof priceId !== "string") return res.status(400).json({ error: "priceId required" });
     planId = PRICE_TO_PLAN[priceId];
@@ -111,6 +118,25 @@ export default async function handler(req, res) {
     }
   }
 
+  // Promo monthly eligibility (issue #137): org must be on trial plan AND have a
+  // promo_code on record (stamped at provisioning). The $45/mo offer is only for
+  // promo-code signups in the free phase — not general-public self-serve.
+  // promo orgs (old one-time pack purchasers) proceed via the regular starter checkout.
+  if (isPromoMonthly) {
+    try {
+      if (!orgId) return res.status(403).json({ error: "This offer isn't available for your account" });
+      const orgRes = await fetch(`${SB_URL}/rest/v1/orgs?id=eq.${orgId}&select=promo_code,plan`, {
+        headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}` },
+      });
+      const org = (await orgRes.json())?.[0];
+      const eligible = org?.promo_code && org.plan === "trial";
+      if (!eligible) return res.status(403).json({ error: "This offer isn't available for your account" });
+    } catch (e) {
+      console.error("[checkout] Promo monthly eligibility check failed:", e.message);
+      return res.status(500).json({ error: "Eligibility check failed" });
+    }
+  }
+
   try {
     // Create Stripe Checkout session — one-time payment for the run pack,
     // subscription for everything else
@@ -129,6 +155,10 @@ export default async function handler(req, res) {
     if (isPack) {
       params.append("metadata[pack_runs]", String(PROMO_PACK_RUNS));
     } else {
+      // Subscription metadata — the webhook reads plan_id to apply org limits.
+      // For promo_monthly, the Stripe Subscription Schedule (created in the webhook
+      // after checkout completes) will overwrite plan_id to "starter" on graduation,
+      // which triggers the automatic upgrade via customer.subscription.updated (issue #137).
       params.append("subscription_data[metadata][user_id]", payload.sub);
       params.append("subscription_data[metadata][org_id]", orgId);
       params.append("subscription_data[metadata][plan_id]", planId);

--- a/api/cron-reset-tokens.js
+++ b/api/cron-reset-tokens.js
@@ -44,9 +44,11 @@ export default async function handler(req, res) {
     const rolloverData = await rolloverRes.json();
     const paidCount = rolloverData?.orgs_processed || 0;
 
-    // Step 1b: Reset max_run_count for paid orgs (Max Mode removed, but
-    // counter should not accumulate indefinitely month-over-month)
-    await fetch(`${SB_URL}/rest/v1/orgs?plan=eq.paid&max_run_count=gt.0`, {
+    // Step 1b: Reset max_run_count for paid and promo_monthly orgs (Max Mode
+    // removed, but counter should not accumulate indefinitely month-over-month).
+    // promo_monthly has max_run_limit=0 so this should always be a no-op for
+    // those orgs, but defensive resets are cheap.
+    await fetch(`${SB_URL}/rest/v1/orgs?plan=in.(paid,promo_monthly)&max_run_count=gt.0`, {
       method: "PATCH",
       headers: {
         apikey: SB_KEY,

--- a/api/stripe-webhook.js
+++ b/api/stripe-webhook.js
@@ -19,12 +19,13 @@ const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
 const processedSessions = new Set();
 const DEDUP_MAX = 500;
 
-// Plan config — same as checkout.js
+// Plan config — same as checkout.js. Keep in sync.
 const PLAN_LIMITS = {
-  starter:    { run_limit: 25,   max_run_limit: 5 },
-  pro:        { run_limit: 100,  max_run_limit: 20 },
-  team:       { run_limit: 250,  max_run_limit: 50 },
-  enterprise: { run_limit: 1000, max_run_limit: 200 },
+  starter:       { run_limit: 25,   max_run_limit: 5 },
+  pro:           { run_limit: 100,  max_run_limit: 20 },
+  team:          { run_limit: 250,  max_run_limit: 50 },
+  enterprise:    { run_limit: 1000, max_run_limit: 200 },
+  promo_monthly: { run_limit: 20,   max_run_limit: 0 },  // issue #137: 2-month promo subscription
 };
 
 // One-time run pack (plan_id "promo_pack") — same as checkout.js
@@ -145,6 +146,120 @@ async function applyRunPack(orgId, session) {
   }
 }
 
+// Promo monthly plan activation (issue #137).
+// Sets the org to plan='promo_monthly' with 20 runs/month and kicks off a Stripe
+// Subscription Schedule that automatically graduates to the starter price after
+// 2 billing cycles — no cron or manual step needed for the upgrade.
+async function applyPromoMonthly(orgId, session) {
+  if (!orgId) return;
+  const subscriptionId = session.subscription || null;
+  const promoEnd = new Date(Date.now() + 60 * 24 * 3600 * 1000).toISOString(); // ~60 days
+
+  try {
+    await fetch(`${SB_URL}/rest/v1/orgs?id=eq.${orgId}`, {
+      method: "PATCH",
+      headers: {
+        apikey: SB_KEY,
+        Authorization: `Bearer ${SB_KEY}`,
+        "Content-Type": "application/json",
+        Prefer: "return=minimal",
+      },
+      body: JSON.stringify({
+        plan: "promo_monthly",
+        run_limit: 20,
+        max_run_limit: 0,
+        run_count: 0,
+        rollover_cap: 20,
+        stripe_subscription_id: subscriptionId,
+        promo_period_end: promoEnd,
+      }),
+    });
+    console.log(`[stripe] Promo monthly activated for org ${orgId}: 20 runs/mo, ends ~${promoEnd}`);
+  } catch (e) {
+    console.error("[stripe] Promo monthly org update failed:", e.message);
+    return; // Do not create schedule if org update failed
+  }
+
+  // Attach a Subscription Schedule: 2 iterations at promo price → starter price forever.
+  // When Stripe advances to the starter phase, customer.subscription.updated fires with
+  // sub.metadata.plan_id='starter' and the existing updateOrg handler graduates the org.
+  if (subscriptionId) {
+    await attachPromoSchedule(subscriptionId);
+  } else {
+    console.warn("[stripe] Promo monthly: no subscription ID in session — schedule not created");
+  }
+}
+
+// Create a Stripe Subscription Schedule that transitions from the promo price to
+// the starter price after 2 billing cycles. Phase 2 sets metadata.plan_id='starter'
+// on the subscription so the existing customer.subscription.updated webhook handler
+// can call updateOrg('starter') without any additional promo-specific logic.
+async function attachPromoSchedule(subscriptionId) {
+  const PROMO_PRICE = process.env.STRIPE_PRICE_PROMO_MONTHLY;
+  const STARTER_PRICE = process.env.STRIPE_PRICE_STARTER;
+  if (!PROMO_PRICE || !STARTER_PRICE) {
+    console.warn("[stripe] attachPromoSchedule: STRIPE_PRICE_PROMO_MONTHLY or STRIPE_PRICE_STARTER not set — schedule skipped");
+    return;
+  }
+
+  // Step 1: create a schedule from the existing subscription (current period → phase 1).
+  const createParams = new URLSearchParams();
+  createParams.append("from_subscription", subscriptionId);
+  let schedule;
+  try {
+    const createRes = await fetch("https://api.stripe.com/v1/subscription_schedules", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${STRIPE_SECRET}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: createParams.toString(),
+    });
+    schedule = await createRes.json();
+    if (schedule.error) {
+      console.error("[stripe] Schedule create failed:", schedule.error.message);
+      return;
+    }
+  } catch (e) {
+    console.error("[stripe] Schedule create network error:", e.message);
+    return;
+  }
+
+  // Step 2: update the schedule with explicit two-phase definition.
+  // Phase 0: promo price, 2 billing cycles total (the current period counts as cycle 1).
+  // Phase 1: starter price, indefinite. end_behavior=release keeps the subscription
+  // running at the starter price after the schedule completes — no cancellation.
+  // Phase 1's metadata overwrites sub.metadata.plan_id to 'starter', which triggers
+  // the existing updateOrg('starter') logic in customer.subscription.updated.
+  const updateParams = new URLSearchParams();
+  updateParams.append("phases[0][items][0][price]", PROMO_PRICE);
+  updateParams.append("phases[0][items][0][quantity]", "1");
+  updateParams.append("phases[0][iterations]", "2");
+  updateParams.append("phases[1][items][0][price]", STARTER_PRICE);
+  updateParams.append("phases[1][items][0][quantity]", "1");
+  updateParams.append("phases[1][metadata][plan_id]", "starter");
+  updateParams.append("end_behavior", "release");
+
+  try {
+    const updateRes = await fetch(`https://api.stripe.com/v1/subscription_schedules/${schedule.id}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${STRIPE_SECRET}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: updateParams.toString(),
+    });
+    const updated = await updateRes.json();
+    if (updated.error) {
+      console.error("[stripe] Schedule update failed:", updated.error.message, "— org will NOT auto-graduate; resolve manually in Stripe");
+    } else {
+      console.log(`[stripe] Promo schedule ${schedule.id} created for subscription ${subscriptionId} — graduates to starter after 2 cycles`);
+    }
+  } catch (e) {
+    console.error("[stripe] Schedule update network error:", e.message);
+  }
+}
+
 async function downgradeOrg(orgId) {
   if (!orgId) return;
 
@@ -213,6 +328,7 @@ export default async function handler(req, res) {
         }
         console.log(`[stripe] Checkout completed: user=${userId}, org=${orgId}, plan=${planId}`);
         if (planId === "promo_pack") await applyRunPack(orgId, session);
+        else if (planId === "promo_monthly") await applyPromoMonthly(orgId, session);
         else await updateOrg(orgId, planId);
         break;
       }

--- a/scripts/daily-health.mjs
+++ b/scripts/daily-health.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// scripts/daily-health.mjs — Daily API health check from api_usage_log (#27)
+//
+// Reports per-endpoint latency percentiles (p50/p95), slow-call counts, and
+// prompt-cache hit rates so speed regressions and cache effectiveness are
+// queryable without the SuperAdmin dashboard.
+//
+// Usage:
+//   node scripts/daily-health.mjs               # last 1 day
+//   node scripts/daily-health.mjs --days=7      # last 7 days
+//   node scripts/daily-health.mjs --by-model    # additionally split by model
+//
+// Requires: SUPABASE_SERVICE_KEY (service_role — same as nightly-backup.mjs).
+// Optional: SUPABASE_URL / VITE_SUPABASE_URL to point at a different project
+// (defaults to the production project used by nightly-backup.mjs).
+// Reads .env.local / .env from the repo root if present.
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+for (const name of [".env.local", ".env"]) {
+  const p = join(ROOT, name);
+  if (!existsSync(p)) continue;
+  for (const line of readFileSync(p, "utf8").split("\n")) {
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+    if (m && process.env[m[1]] === undefined) {
+      let val = m[2];
+      if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'")))
+        val = val.slice(1, -1);
+      process.env[m[1]] = val;
+    }
+  }
+}
+
+const SB_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || "https://xtnidawfuaxwwwcnkewu.supabase.co";
+const SB_KEY = process.env.SUPABASE_SERVICE_KEY;
+if (!SB_KEY) {
+  console.error("SUPABASE_SERVICE_KEY not set. Get it from Supabase Dashboard → Settings → API → service_role key.");
+  process.exit(1);
+}
+
+const args = Object.fromEntries(process.argv.slice(2).map(a => {
+  const m = a.match(/^--([a-z-]+)(?:=(.*))?$/);
+  return m ? [m[1], m[2] ?? true] : [a, true];
+}));
+const DAYS = Math.max(1, parseInt(args.days, 10) || 1);
+const BY_MODEL = !!args["by-model"];
+const SLOW_MS = 60_000; // acceptance criterion for #27: no call >60s at p95
+
+const since = new Date(Date.now() - DAYS * 86_400_000).toISOString();
+
+function percentile(sorted, p) {
+  if (!sorted.length) return null;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)];
+}
+
+const fmtMs = v => v == null ? "—" : v >= 10_000 ? `${(v / 1000).toFixed(1)}s` : `${v}ms`;
+const pct = (n, d) => d ? `${((100 * n) / d).toFixed(1)}%` : "—";
+
+async function fetchRows() {
+  // Page through PostgREST results (default server cap is 1000 rows).
+  const rows = [];
+  const PAGE = 1000;
+  for (let offset = 0; ; offset += PAGE) {
+    const url = `${SB_URL}/rest/v1/api_usage_log` +
+      `?select=endpoint,model,duration_ms,input_tokens,cache_read_tokens,cache_creation_tokens,created_at` +
+      `&created_at=gte.${encodeURIComponent(since)}` +
+      `&order=created_at.desc&limit=${PAGE}&offset=${offset}`;
+    const res = await fetch(url, { headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}` } });
+    if (!res.ok) {
+      console.error(`api_usage_log query failed: ${res.status} — ${(await res.text()).slice(0, 200)}`);
+      process.exit(1);
+    }
+    const page = await res.json();
+    rows.push(...page);
+    if (page.length < PAGE || rows.length >= 100_000) break;
+  }
+  return rows;
+}
+
+function summarize(rows) {
+  const durations = rows.map(r => r.duration_ms).filter(v => Number.isFinite(v)).sort((a, b) => a - b);
+  const cacheReads = rows.filter(r => (r.cache_read_tokens || 0) > 0).length;
+  const cacheWrites = rows.filter(r => (r.cache_creation_tokens || 0) > 0).length;
+  return {
+    calls: rows.length,
+    withDuration: durations.length,
+    p50: percentile(durations, 50),
+    p95: percentile(durations, 95),
+    max: durations.length ? durations[durations.length - 1] : null,
+    slow: durations.filter(v => v > SLOW_MS).length,
+    cacheReads,
+    cacheWrites,
+  };
+}
+
+function printTable(title, groups) {
+  console.log(`\n--- ${title} ---`);
+  const header = ["group", "calls", "p50", "p95", "max", `>${SLOW_MS / 1000}s`, "cache-hit", "cache-write"];
+  const lines = [header];
+  for (const [name, s] of groups) {
+    lines.push([
+      name, String(s.calls), fmtMs(s.p50), fmtMs(s.p95), fmtMs(s.max),
+      String(s.slow), pct(s.cacheReads, s.calls), pct(s.cacheWrites, s.calls),
+    ]);
+  }
+  const widths = lines[0].map((_, i) => Math.max(...lines.map(l => l[i].length)));
+  for (const l of lines) console.log("  " + l.map((c, i) => c.padEnd(widths[i] + 2)).join(""));
+}
+
+async function main() {
+  console.log(`\n=== CAMBRIAN CATALYST DAILY HEALTH CHECK ===`);
+  console.log(`Window: last ${DAYS} day(s) (since ${since})`);
+  console.log(`Source: ${SB_URL} api_usage_log`);
+
+  const rows = await fetchRows();
+  if (!rows.length) {
+    console.log("\nNo api_usage_log rows in window — nothing to report.");
+    return;
+  }
+
+  // Overall
+  printTable("OVERALL", [["all", summarize(rows)]]);
+
+  // Per endpoint (p50/p95 duration_ms by endpoint — #27 measurement task)
+  const byEndpoint = new Map();
+  for (const r of rows) {
+    const key = r.endpoint || "unknown";
+    if (!byEndpoint.has(key)) byEndpoint.set(key, []);
+    byEndpoint.get(key).push(r);
+  }
+  printTable("BY ENDPOINT", [...byEndpoint.entries()]
+    .sort((a, b) => b[1].length - a[1].length)
+    .map(([k, v]) => [k, summarize(v)]));
+
+  if (BY_MODEL) {
+    const byModel = new Map();
+    for (const r of rows) {
+      const key = `${r.endpoint || "unknown"} / ${r.model || "unknown"}`;
+      if (!byModel.has(key)) byModel.set(key, []);
+      byModel.get(key).push(r);
+    }
+    printTable("BY ENDPOINT / MODEL", [...byModel.entries()]
+      .sort((a, b) => b[1].length - a[1].length)
+      .map(([k, v]) => [k, summarize(v)]));
+  }
+
+  // Long-pole detail: the 10 slowest calls in the window
+  const slowest = rows.filter(r => Number.isFinite(r.duration_ms))
+    .sort((a, b) => b.duration_ms - a.duration_ms).slice(0, 10);
+  console.log(`\n--- 10 SLOWEST CALLS ---`);
+  for (const r of slowest) {
+    console.log(`  ${fmtMs(r.duration_ms).padEnd(8)} ${(r.endpoint || "?").padEnd(14)} ${(r.model || "?").padEnd(28)} in:${r.input_tokens || 0} cacheRead:${r.cache_read_tokens || 0} ${r.created_at}`);
+  }
+  console.log("");
+}
+
+main().catch(e => { console.error("Health check failed:", e); process.exit(1); });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8970,7 +8970,8 @@ Return ONLY raw JSON:
     if(d.contactRole) setContactRole(d.contactRole);
     if(d.dealClassification) setDealClassification(d.dealClassification);
     if(d.importMode) setImportMode(d.importMode);
-    setShowSessions(false);setStep(d.step!=null?d.step:(d.sellerUrl?1:0));
+    // mergedPlay (issue #28): step 6 (Game Plan) is retired — sessions saved there land on the merged Brief
+    setShowSessions(false);setStep(d.step!=null?(mergedPlay&&d.step===6?5:d.step):(d.sellerUrl?1:0));
     // Reset auto-save snapshot so restored state isn't immediately re-saved
     lastAutoSaveSnap.current = JSON.stringify(d);
     // Stale session warning — 14+ days old
@@ -9070,6 +9071,15 @@ Return ONLY raw JSON:
       }
       // Arrow keys & number keys — stage navigation (disabled during in-call to prevent accidental navigation)
       if (step === 7) return; // In-call: no keyboard nav
+      // mergedPlay (issue #28): step 6 (Game Plan) is retired — arrows/jumps skip over it
+      if (mergedPlay) {
+        if (e.key === "ArrowRight" && step < 9) { setStep(s => { const n = Math.min(s + 1, 9); return n === 6 ? 7 : n; }); return; }
+        if (e.key === "ArrowLeft"  && step > 0) { setStep(s => { const n = Math.max(s - 1, 0); return n === 6 ? 5 : n; }); return; }
+        if (e.key === "0") { setStep(9); return; }
+        const numM = parseInt(e.key, 10);
+        if (numM >= 1 && numM <= 9) { setStep(numM - 1 === 6 ? 7 : numM - 1); return; }
+        return;
+      }
       if (e.key === "ArrowRight" && step < 9) { setStep(s => Math.min(s + 1, 9)); return; }
       if (e.key === "ArrowLeft"  && step > 0) { setStep(s => Math.max(s - 1, 0)); return; }
       // Number keys 1-9, 0 — jump to stage (user-facing 1-10, internal 0-9)
@@ -9373,6 +9383,11 @@ Return ONLY raw JSON:
     console.log("[sol-con] Brief quorum met — firing pre-call SA + hypothesis in parallel");
     buildSolutionFit({ preCall: true });
     if (!riverHypo && !riverHypoLoading) buildRiverHypo(brief, selectedAccount);
+    // mergedPlay (issue #28): with the Game Plan step retired, the gate map's old build
+    // trigger ("Prep for the Call →" click) no longer runs before the map is needed —
+    // build it here at quorum so the Approval Gate Map card in the merged Brief layout
+    // populates without user action. Idempotent (buildGateMap no-ops if already present).
+    if (mergedPlay) buildGateMap(brief, selectedAccount);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [brief?._completedSections, !!brief, !!selectedAccount, !!sellerICP]);
 
@@ -13299,7 +13314,7 @@ Return ONLY raw JSON:
     { id:"nav-accounts",icon:"📊", label:"Go to Fit Check",    section:"Navigate", action:()=>setStep(3) },
     { id:"nav-review",  icon:"👁", label:"Go to Account Review",section:"Navigate", action:()=>setStep(4) },
     { id:"nav-brief",   icon:"📋", label:"Go to Brief",        section:"Navigate", action:()=>setStep(5) },
-    { id:"nav-hypo",    icon:"🧪", label:"Go to Hypothesis",   section:"Navigate", action:()=>setStep(6) },
+    { id:"nav-hypo",    icon:"🧪", label:"Go to Hypothesis",   section:"Navigate", action:()=>setStep(mergedPlay?5:6) },
     { id:"nav-incall",  icon:"🎙", label:"Go to In-Call",      section:"Navigate", action:()=>setStep(7) },
     { id:"nav-sa",      icon:"🏗", label:"Go to Solution Fit", section:"Navigate", action:()=>setStep(8) },
     { id:"nav-post",    icon:"📬", label:"Go to Post-Call",    section:"Navigate", action:()=>setStep(9) },
@@ -13736,6 +13751,8 @@ Return ONLY raw JSON:
               if (sellerUrl === "research-only" && i !== 0 && i !== 5) return null;
               // When solution consolidation is on, Step 8 is absorbed into Step 6 — hide it
               if (solConEnabled && i === 8) return null;
+              // When mergedPlay is on (issue #28), Step 6 (Game Plan) is absorbed into Step 5 (Brief) — hide it
+              if (mergedPlay && i === 6) return null;
               const canNav = (()=>{
                 if(i===step) return false;
                 if(i===0) return true;
@@ -13763,7 +13780,7 @@ Return ONLY raw JSON:
                     aria-current={step===i?"step":undefined}
                     title={STEP_TIPS[i] || s}
                     style={{position:"relative"}}>
-                    <div className={`step-num ${celebrateStep===i?"just-completed":""}`}>{step>i?"✓":(solConEnabled&&i>8?i:i+1)}</div>
+                    <div className={`step-num ${celebrateStep===i?"just-completed":""}`}>{step>i?"✓":(mergedPlay&&i>6?(solConEnabled&&i>8?i-1:i):(solConEnabled&&i>8?i:i+1))}</div>
                     <div className="step-label">{s}</div>
                     {i === 1 && ((rfpData.open?.length || 0) + (rfpData.signals?.length || 0) + (accountRfpData.open?.length || 0) + (accountRfpData.signals?.length || 0) > 0) && (
                       <span style={{position:"absolute",top:-4,right:-4,background:"var(--red)",color:"white",fontSize:8,fontWeight:800,width:16,height:16,borderRadius:"50%",display:"flex",alignItems:"center",justifyContent:"center"}}>
@@ -17435,7 +17452,9 @@ Return ONLY raw JSON:
                     {(briefLoading || brief?._error || brief?._failedSections?.length > 0 || Object.values(brief?._loadingSections || {}).some(Boolean)) && (
                     <button className="btn btn-secondary" disabled={briefLoading} onClick={()=>{if(!checkNoChange("brief",getBriefSig,()=>pickAccount(selectedAccount)))pickAccount(selectedAccount);}}>{briefLoading ? "⏳ Regenerating..." : "↻ Regenerate"}</button>
                     )}
-                    {sellerUrl!=="research-only"&&<button className="btn btn-green btn-lg" onClick={()=>{if(!riverHypo&&!riverHypoLoading&&brief)buildRiverHypo(brief,selectedAccount);buildGateMap(brief,selectedAccount);setStep(6);}}>Prep for the Call →</button>}
+                    {sellerUrl!=="research-only"&&(mergedPlay
+                      ? <button className="btn btn-green btn-lg" onClick={()=>{if(!riverHypo&&!riverHypoLoading&&brief)buildRiverHypo(brief,selectedAccount);buildGateMap(brief,selectedAccount);setActiveRiver(0);setStep(7);}}>Start the Call →</button>
+                      : <button className="btn btn-green btn-lg" onClick={()=>{if(!riverHypo&&!riverHypoLoading&&brief)buildRiverHypo(brief,selectedAccount);buildGateMap(brief,selectedAccount);setStep(6);}}>Prep for the Call →</button>)}
                     <button className="btn btn-secondary" onClick={clearAccount} title="Clear this account and go back to Fit Scores">Switch Account</button>
                   </div>
                 </div>
@@ -18708,7 +18727,9 @@ Return ONLY raw JSON:
                   <button className="btn btn-secondary" disabled={briefLoading} onClick={()=>{if(!checkNoChange("brief",getBriefSig,()=>pickAccount(selectedAccount)))pickAccount(selectedAccount);}}>{briefLoading ? "⏳ Regenerating..." : "↻ Regenerate"}</button>
                   )}
                   <ExportMenu locked={exportLocked} onPDF={doExport} onCSV={()=>csvExport("Brief", brief)} />
-                  <button className="btn btn-green btn-lg" onClick={()=>{if(!riverHypo&&!riverHypoLoading&&brief)buildRiverHypo(brief,selectedAccount);buildGateMap(brief,selectedAccount);setStep(6);}}>Prep for the Call →</button>
+                  {mergedPlay
+                    ? <button className="btn btn-green btn-lg" onClick={()=>{if(!riverHypo&&!riverHypoLoading&&brief)buildRiverHypo(brief,selectedAccount);buildGateMap(brief,selectedAccount);setActiveRiver(0);setStep(7);}}>Start the Call →</button>
+                    : <button className="btn btn-green btn-lg" onClick={()=>{if(!riverHypo&&!riverHypoLoading&&brief)buildRiverHypo(brief,selectedAccount);buildGateMap(brief,selectedAccount);setStep(6);}}>Prep for the Call →</button>}
                 </div>
               </>
             )}
@@ -19020,9 +19041,11 @@ Return ONLY raw JSON:
               <div style={{display:"flex",gap:8,alignItems:"center",flexWrap:"wrap"}}>
                 <div style={{fontFamily:"'Crimson Pro',serif",fontSize:24,fontWeight:600,color:confColor(confidence)}}>{confidence}%</div>
                 <div style={{fontSize:12,color:"var(--ink-3)"}}>confidence</div>
-                <button className="btn btn-secondary btn-sm" onClick={()=>setStep(6)}>← Hypothesis</button>
+                {mergedPlay
+                  ? <button className="btn btn-secondary btn-sm" onClick={()=>setStep(5)}>← Brief</button>
+                  : <button className="btn btn-secondary btn-sm" onClick={()=>setStep(6)}>← Hypothesis</button>}
                 <ExportMenu locked={exportLocked} onPDF={doExport} onCSV={()=>csvExport("In-Call", {gateAnswers,riverData,gateNotes,notes,confidence})} />
-                <button className="btn btn-green btn-sm" onClick={()=>{buildSolutionFit();setStep(solConEnabled?6:8);}} disabled={solutionFitLoading}>
+                <button className="btn btn-green btn-sm" onClick={()=>{buildSolutionFit();setStep(mergedPlay?5:(solConEnabled?6:8));}} disabled={solutionFitLoading}>
                   {solutionFitLoading?"Analyzing...":"End Call →"}
                 </button>
               </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14419,34 +14419,55 @@ Return ONLY raw JSON:
                       <span style={{fontSize:14}}>✓</span> {productUrls.filter(u=>u.url).length} product page{productUrls.filter(u=>u.url).length!==1?"s":""} confirmed
                     </div>
                   )}
+                  {/* Single context affordance (#29) — the ONLY card the light path shows:
+                      upload + funding-stage chip + segment chip. The "Add more details"
+                      expander below is suppressed while this card is visible so the two
+                      affordances never stack. Free-text description removed — structured
+                      inputs + uploaded docs only. */}
                   {urlScanStatus==="none"&&(
                     <div style={{background:"var(--bg-1)",border:"1.5px solid var(--line-0)",borderRadius:10,padding:"14px 16px",marginTop:10}}>
                       <div style={{fontSize:13,fontWeight:700,color:"var(--ink-0)",marginBottom:6}}>Let's add a little context</div>
                       <div style={{fontSize:12,color:"var(--ink-1)",lineHeight:1.6,marginBottom:12}}>
                         Looks like your company's website is a little light on product, services, solutions, and case-study content.
-                        Not a problem — use the upload button to add relevant materials (case studies, product one-pagers, etc.),
-                        or use the text field below to describe the products, solutions, or services you're focused on selling.
+                        Not a problem — upload relevant materials (case studies, product one-pagers, etc.) and pick the options below.
                       </div>
-                      <div style={{display:"flex",gap:8,flexWrap:"wrap",alignItems:"center"}}>
-                        {/* Reuses the existing docs pipeline — same input + handler as the header "+ Add Docs" (handleDocFiles @5725 → sellerDocs) */}
+                      <div style={{display:"flex",gap:8,flexWrap:"wrap",alignItems:"center",marginBottom:12}}>
+                        {/* Reuses the existing docs pipeline — same input + handler as the header "+ Add Docs" (handleDocFiles @5725 → sellerDocs → proof pack) */}
                         <label className="btn btn-secondary btn-sm" style={{cursor:"pointer"}}>
                           <input type="file" accept=".pdf,.docx,.doc,.txt,.md,.pptx,.csv,.xlsx,.xls,.png,.jpg,.jpeg,.webp,.gif,.bmp" multiple style={{display:"none"}}
                             onChange={e=>{handleDocFiles(e.target.files);e.target.value="";}}/>
                           📂 Upload materials
                         </label>
-                        <button className="btn btn-secondary btn-sm"
-                          onClick={()=>{
-                            setCollapsedBB(prev=>{const next=new Set(prev);next.delete("setupDetails");return next;});
-                            setTimeout(()=>{document.getElementById("kickoffv2-icp-input")?.focus();},80);
-                          }}>
-                          ✏️ Describe what you sell
-                        </button>
                         {sellerDocs.length>0&&(
                           <span style={{fontSize:11,fontWeight:600,color:"var(--green)"}}>✓ {sellerDocs.length} doc{sellerDocs.length>1?"s":""} added</span>
                         )}
                       </div>
+                      <div style={{marginBottom:10}}>
+                        <div style={{fontSize:11,fontWeight:700,color:"var(--ink-2)",textTransform:"uppercase",letterSpacing:"0.5px",marginBottom:6}}>Your Funding Stage</div>
+                        <div style={{display:"flex",flexWrap:"wrap",gap:6}}>
+                          {["Bootstrapped","Angel","Seed","Series A","Series B","Series C","Series D+","PE-Backed","Private","Public"].map(stage=>(
+                            <button key={stage} onClick={()=>setSellerStage(stage)}
+                              style={{padding:"5px 12px",borderRadius:20,border:"1.5px solid "+(sellerStage===stage?"var(--ink-0)":"var(--line-0)"),
+                                background:sellerStage===stage?"var(--ink-0)":"var(--surface)",color:sellerStage===stage?"#fff":"var(--ink-1)",
+                                fontSize:12,fontWeight:700,cursor:"pointer",transition:"all 0.13s"}}>
+                              {stage}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                      <div>
+                        <div style={{fontSize:11,fontWeight:600,color:"var(--ink-2)",marginBottom:4}}>Market Segment <span style={{fontWeight:400,color:"var(--ink-3)"}}>pick 1</span></div>
+                        <div style={{display:"flex",flexWrap:"wrap",gap:5}}>
+                          {["SMB","Mid-Market","Enterprise"].map(v=>{
+                            const sel=icpTargeting.segment===v;
+                            return <button key={v} onClick={()=>setIcpTargeting(p=>({...p,segment:sel?"":v}))}
+                              style={{padding:"5px 10px",borderRadius:20,fontSize:11,fontWeight:700,cursor:"pointer",transition:"all 0.13s",
+                                border:"1.5px solid "+(sel?"var(--navy)":"var(--line-0)"),background:sel?"var(--navy)":"var(--surface)",color:sel?"#fff":"var(--ink-1)"}}>{v}</button>;
+                          })}
+                        </div>
+                      </div>
                       <div style={{fontSize:11,color:"var(--ink-3)",marginTop:10}}>
-                        Either one works. Then continue below — you'll build your ICP on the next step with whatever you add here.
+                        Then continue below — you'll build your ICP on the next step with whatever you add here.
                       </div>
                     </div>
                   )}
@@ -14463,13 +14484,16 @@ Return ONLY raw JSON:
                 </div>
 
                 {/* Add more details — collapsed disclosure; binds the SAME state the classic form feeds
-                    into the ICP prompt (sellerStage @7754, icpTargeting @5817-5824, sellerICPInput @8270) */}
+                    into the ICP prompt (sellerStage @7754, icpTargeting @5817-5824). Suppressed on the
+                    light path (#29) — the "Let's add a little context" card above carries the same
+                    chips there, so only one affordance ever shows. */}
+                {urlScanStatus!=="none"&&(
                 <div style={{marginTop:14}}>
                   <div onClick={()=>toggleBB("setupDetails")} style={{cursor:"pointer",display:"flex",alignItems:"center",gap:8,padding:"8px 12px",background:"var(--bg-1)",borderRadius:8,border:"1px solid var(--line-0)"}}>
                     <span style={{fontSize:13}}>{bbIsOpen("setupDetails")?"▾":"▸"}</span>
                     <div style={{flex:1}}>
                       <div style={{fontSize:12,fontWeight:700,color:"var(--ink-1)"}}>Add more details <span style={{fontWeight:400,color:"var(--ink-3)"}}>(optional — improves targeting)</span></div>
-                      <div style={{fontSize:10,color:"var(--ink-3)"}}>Funding stage, market segment, your own ICP notes</div>
+                      <div style={{fontSize:10,color:"var(--ink-3)"}}>Funding stage, market segment</div>
                     </div>
                     {sellerStage && <span style={{fontSize:10,fontWeight:700,background:"var(--green-bg)",color:"var(--green)",borderRadius:10,padding:"2px 8px"}}>{sellerStage}</span>}
                   </div>
@@ -14487,7 +14511,7 @@ Return ONLY raw JSON:
                         ))}
                       </div>
                     </div>
-                    <div style={{marginBottom:10}}>
+                    <div>
                       <div style={{fontSize:11,fontWeight:600,color:"var(--ink-2)",marginBottom:4}}>Market Segment <span style={{fontWeight:400,color:"var(--ink-3)"}}>pick 1</span></div>
                       <div style={{display:"flex",flexWrap:"wrap",gap:5}}>
                         {["SMB","Mid-Market","Enterprise"].map(v=>{
@@ -14498,18 +14522,9 @@ Return ONLY raw JSON:
                         })}
                       </div>
                     </div>
-                    <div>
-                      <div style={{fontSize:11,fontWeight:600,color:"var(--ink-2)",marginBottom:4}}>Anything else we should know? <span style={{fontWeight:400,color:"var(--ink-3)"}}>your ICP, in your own words</span></div>
-                      <textarea
-                        id="kickoffv2-icp-input"
-                        value={sellerICPInput}
-                        onChange={e=>setSellerICPInput(e.target.value)}
-                        placeholder={"e.g. \"We sell to SMB restaurants with 1-5 locations, owner-operators, $500K-$5M revenue\""}
-                        style={{width:"100%",minHeight:60,padding:"10px 12px",fontSize:13,border:"1.5px solid var(--line-0)",borderRadius:8,resize:"vertical",fontFamily:"inherit",lineHeight:1.6,background:"var(--bg-0)"}}
-                      />
-                    </div>
                   </div>
                 </div>
+                )}
 
                 {/* Single context-aware primary CTA — no two stacked full-width buttons:
                     pre-scan  → run the EXISTING Go pipeline (scan / disambiguation), label "Analyze my company →";

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8822,6 +8822,53 @@ Return ONLY raw JSON:
         }
       }
 
+      // Firecrawl discovery fallback (#29) — search-index discovery is unreliable on
+      // thin or poorly-indexed sites (cambriancatalyst.ai itself reproduced 8/8).
+      // When discovery returns <3 pages, probe the standard marketing paths directly
+      // via /api/fetch (plain fetch → Firecrawl render escalation, render:"auto").
+      // Probed pages carry the SAME trust level as discovered ones — URL hints for
+      // the ICP research pass, never ground truth. Probes fire concurrently with no
+      // retries; any failure (404, timeout, SSRF block) is a silent per-path skip.
+      if(pages.length<3){
+        console.log(`[scan] Discovery returned ${pages.length} page(s) — probing standard paths via /api/fetch fallback`);
+        const candidates=[
+          {path:"",label:"Homepage",type:""},
+          {path:"/products",label:"Products",type:"product"},
+          {path:"/solutions",label:"Solutions",type:"product"},
+          {path:"/customers",label:"Customers",type:"case_study"},
+          {path:"/case-studies",label:"Case Studies",type:"case_study"},
+          {path:"/about",label:"About",type:""},
+        ];
+        const probed=await Promise.all(candidates.map(async(c)=>{
+          try{
+            const r=await fetch("/api/fetch",{method:"POST",headers:authHeaders(),body:JSON.stringify({url:baseUrl+c.path,render:"auto"})});
+            if(!r.ok) return null;
+            const fd=await r.json();
+            // ok:false (404/timeout/blocked) or near-empty text → skip silently
+            if(!fd?.ok||!fd.text||fd.text.length<200) return null;
+            // Same-domain guard on the post-redirect URL (same idiom as the p2-fetch pipeline)
+            if(fd.finalUrl){
+              try{
+                const h=new URL(fd.finalUrl).hostname.replace(/^www\./,"").toLowerCase();
+                const base=url.split("/")[0].replace(/^www\./,"").toLowerCase();
+                if(!h.includes(base)&&!base.includes(h)) return null;
+              }catch{ return null; }
+            }
+            return {url:fd.finalUrl||baseUrl+c.path,label:c.label,type:c.type};
+          }catch{ return null; } // one failed probe must never break the scan
+        }));
+        // Merge into the discovery result, dedupe by normalized URL
+        const normUrl=(u)=>u.replace(/^https?:\/\//,"").replace(/^www\./,"").replace(/\/$/,"").toLowerCase();
+        const seen=new Set(pages.map(p=>normUrl(p.url)));
+        for(const p of probed){
+          if(!p||seen.has(normUrl(p.url))) continue;
+          seen.add(normUrl(p.url));
+          pages.push(p);
+        }
+        pages=pages.slice(0,8);
+        console.log(`[scan] Direct-probe fallback merged: ${probed.filter(Boolean).length} probe hit(s) → ${pages.length} page(s) total`);
+      }
+
       console.log("URL scan found pages:", pages.length, pages);
       if(pages.length>0){
         setProductUrls(pages.map(p=>({url:p.url,label:p.label||"",type:p.type||""})));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import SuperAdmin from "./components/SuperAdmin.jsx";
 import UserDashboard from "./components/UserDashboard.jsx";
 import S9SolutionFit from "./stages/S9_SolutionFit.jsx";
 import { computeFitScore, buildSignalExtractionPrompt, labelForScore } from "./lib/fitScoring.js";
+import { MERGED_PLAY } from "./config/constants.js";
 
 // ── Sortable column header for Fit Check table ──
 function FitSortTh({ sortKey, sortDir, onSort, colKey, children, style }) {
@@ -5677,6 +5678,13 @@ export default function App(){
   // Canonical Solution Thesis = { riverHypo, solutionFit } — both already
   //   persisted in getSessionSnap(); no new state needed.
   const solConEnabled = (() => { try { return localStorage.getItem("cc_sol_consolidation") !== "off"; } catch { return true; } })();
+  // ── MERGED PLAY FEATURE FLAG (issue #28) ────────────────────────────────────
+  // Default comes from config (MERGED_PLAY, ships OFF). When ON: the Game Plan
+  // step's solutionMapping + hypothesis content renders inside the Brief's Play
+  // section (render move — zero new model calls) and step 7 (Game Plan) is
+  // retired from the stepper. When OFF: behavior is byte-identical to today.
+  // localStorage "cc_merged_play" = "on" | "off" overrides for staging QA.
+  const mergedPlay = (() => { try { const v = localStorage.getItem("cc_merged_play"); if (v === "on") return true; if (v === "off") return false; } catch { /* config default */ } return MERGED_PLAY; })();
   const[briefStatus,setBriefStatus]=useState("");
   const[briefError,setBriefError]=useState("");
   const[riverHypo,setRiverHypo]=useState(null);
@@ -17107,6 +17115,226 @@ Return ONLY raw JSON:
                   );
                 })()}
                 {/* ── END THE PLAY card ─────────────────────────────────── */}
+
+                {/* ── MERGED GAME PLAN (issue #28, flag: mergedPlay) ──────
+                    When ON, the former Game Plan step's solutionMapping +
+                    hypothesis content renders here, directly under The Play
+                    card. Pure render move — same state (brief.solutionMapping,
+                    solutionFit, riverHypo), zero new model calls: the pre-call
+                    auto-run and buildThePlay() already populate everything.
+                    When OFF this block is skipped entirely and the Game Plan
+                    step (step===6 below) renders unchanged — that block stays
+                    the source of truth for the OFF path; this JSX mirrors it. */}
+                {mergedPlay && sellerUrl !== "research-only" && (
+                  <div style={{marginBottom:16}}>
+                    <div style={{display:"flex",alignItems:"center",gap:12,margin:"4px 0 14px"}}>
+                      <div style={{flex:1,height:1,background:"var(--line-0)"}}/>
+                      <div style={{fontSize:11,fontWeight:700,color:"var(--ink-3)",textTransform:"uppercase",letterSpacing:"0.6px"}}>Game Plan</div>
+                      <div style={{flex:1,height:1,background:"var(--line-0)"}}/>
+                    </div>
+                    {solConEnabled&&(
+                      <>
+                        {/* Pre-call brief solutions summary (read-only) — shown until SA built */}
+                        {!solutionFit&&!solutionFitLoading&&(brief?.solutionMapping||[]).filter(s=>s?.product).length>0&&(
+                          <div className="bb" style={{marginBottom:14}}>
+                            <div className="bb-hdr">
+                              <div className="bb-icon" style={{fontSize:14}}>🎯</div>
+                              <div>
+                                <div className="bb-title">Solutions for {selectedAccount?.company}</div>
+                                <div className="bb-sub">From your brief — confirmed or revised post-call</div>
+                              </div>
+                            </div>
+                            <div className="bb-body" style={{display:"flex",flexDirection:"column",gap:10}}>
+                              {(brief.solutionMapping||[]).filter(s=>s?.product).map((s,i)=>(
+                                <div key={i} className="solution-item">
+                                  <div className="sol-badge">{s.product}</div>
+                                  <div style={{fontSize:13,color:"var(--ink-1)",lineHeight:1.6}}>{s.fit}</div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Full SA architecture — embedded (no wrapper/action bar; owns all SA content) */}
+                        <S9SolutionFit
+                          embedded
+                          solutionFit={solutionFit}
+                          solutionFitLoading={solutionFitLoading}
+                          selectedAccount={selectedAccount}
+                          onRun={buildSolutionFit}
+                          onRegenerate={()=>{setSolutionFit(null);setSolutionFitLoading(true);setTimeout(buildSolutionFit,100);}}
+                        />
+
+                        {/* Divider before RIVER section */}
+                        <div style={{display:"flex",alignItems:"center",gap:12,margin:"20px 0 14px"}}>
+                          <div style={{flex:1,height:1,background:"var(--line-0)"}}/>
+                          <div style={{fontSize:11,fontWeight:700,color:"var(--ink-3)",textTransform:"uppercase",letterSpacing:"0.6px"}}>RIVER Strategy</div>
+                          <div style={{flex:1,height:1,background:"var(--line-0)"}}/>
+                        </div>
+                      </>
+                    )}
+
+                    {/* Recommended Solutions — flag OFF only (original behavior) */}
+                    {!solConEnabled&&(brief?.solutionMapping||[]).filter(s=>s?.product).length>0&&(
+                      <div className="bb" style={{marginBottom:16}}>
+                        <div className="bb-hdr">
+                          <div className="bb-icon" style={{fontSize:14}}>🎯</div>
+                          <div>
+                            <div className="bb-title">Solutions You're Selling into {selectedAccount?.company}</div>
+                            <div className="bb-sub">How each offering maps to what this account needs</div>
+                          </div>
+                        </div>
+                        <div className="bb-body" style={{display:"flex",flexDirection:"column",gap:10}}>
+                          {(brief.solutionMapping||[]).filter(s=>s?.product).map((s,i)=>(
+                            <div key={i} className="solution-item">
+                              <div className="sol-badge">{s.product}</div>
+                              <div style={{fontSize:13,color:"var(--ink-1)",lineHeight:1.6}}>{s.fit}</div>
+                            </div>
+                          ))}
+                          {brief?.openingAngle&&(
+                            <div style={{marginTop:4,paddingTop:12,borderTop:"1px solid var(--line-1)"}}>
+                              <div style={{fontSize:10,fontWeight:700,color:"var(--tan-0)",textTransform:"uppercase",letterSpacing:"0.5px",marginBottom:5}}>Opening Angle</div>
+                              <div style={{fontSize:13,color:"var(--ink-1)",lineHeight:1.6,fontStyle:"italic"}}>"{brief.openingAngle}"</div>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                    {riverHypoLoading&&(
+                      <div className="load-box" style={{marginBottom:20}}>
+                        <div className="load-status">
+                          <div className="load-spin"/>
+                          {getQuip("hypothesis")}
+                        </div>
+                        <div style={{height:3,background:"var(--tan-3)",borderRadius:2,overflow:"hidden",marginTop:12}}>
+                          <div style={{height:"100%",background:"linear-gradient(90deg,var(--tan-0),var(--navy),var(--green),var(--tan-0))",backgroundSize:"300% 100%",animation:"shimmer 2.5s linear infinite",borderRadius:2}}/>
+                        </div>
+                        <div style={{fontSize:11,color:"var(--ink-3)",textAlign:"center",marginTop:8}}>
+                          This usually finishes before you're done reading the brief
+                        </div>
+                      </div>
+                    )}
+
+                    {riverHypo&&(
+                      <>
+                        {/* RIVER fields — Quick Summary + Expand */}
+                        {[
+                          {key:"reality",    label:"R — Reality",      icon:"📍", sub:"Current state", color:"var(--navy)"},
+                          {key:"impact",     label:"I — Impact",       icon:"💥", sub:"Cost of inaction", color:"var(--red)"},
+                          {key:"vision",     label:"V — Vision",       icon:"🔭", sub:"What success looks like", color:"var(--green)"},
+                          {key:"entryPoints",label:"E — Entry Points", icon:"🚪", sub:"Decision-makers", color:"var(--purple)"},
+                          {key:"route",      label:"R — Route",        icon:"🗺", sub:"Fastest path to close", color:"var(--tan-0)"},
+                        ].map(({key,label,icon,sub,color})=>(
+                          <RiverFieldCard
+                            key={key}
+                            fieldKey={key}
+                            label={label}
+                            icon={icon}
+                            sub={sub}
+                            color={color}
+                            value={String(riverHypo[key]||"")}
+                            onChange={v=>setRiverHypo(prev=>({...prev,[key]:v}))}
+                          />
+                        ))}
+
+                        {/* Opening Angle */}
+                        <div className="bb" style={{marginBottom:10}}>
+                          <div className="bb-hdr">
+                            <div className="bb-icon" style={{fontSize:14}}>🎯</div>
+                            <div><div className="bb-title">Opening Angle</div><div className="bb-sub">The insight that makes everything click</div></div>
+                          </div>
+                          <div className="bb-body">
+                            <EF
+                              value={riverHypo.openingAngle||""}
+                              onChange={v=>setRiverHypo(prev=>({...prev,openingAngle:v}))}
+                              placeholder="Click to edit opening angle..."
+                            />
+                          </div>
+                        </div>
+
+                        {/* Challenger Insight */}
+                        {riverHypo.challengerInsight&&(
+                          <div className="bb" style={{marginBottom:10}}>
+                            <div className="bb-hdr">
+                              <div className="bb-icon" style={{fontSize:14}}>⚡</div>
+                              <div><div className="bb-title">Teaching Insight</div><div className="bb-sub">The assumption to challenge — teach this to the organization through your champion</div></div>
+                            </div>
+                            <div className="bb-body">
+                              <div style={{background:"var(--green-bg)",border:"2px solid var(--green)",borderRadius:8,padding:"12px 16px"}}>
+                                <div style={{fontSize:9,fontWeight:700,color:"var(--green)",textTransform:"uppercase",letterSpacing:"0.4px",marginBottom:6}}>The Teaching Insight</div>
+                                <div style={{fontSize:14,color:"var(--ink-0)",lineHeight:1.7,fontStyle:"italic"}}>"{riverHypo.challengerInsight}"</div>
+                              </div>
+                            </div>
+                          </div>
+                        )}
+
+                        {/* JOLT Plan */}
+                        {riverHypo.joltPlan&&(riverHypo.joltPlan.judgeIndecision||riverHypo.joltPlan.recommendation)&&(
+                          <div className="bb" style={{marginBottom:10}}>
+                            <div className="bb-hdr">
+                              <div className="bb-icon" style={{fontSize:14}}>🛡</div>
+                              <div><div className="bb-title">Overcoming Indecision</div><div className="bb-sub">Indecision kills 40-60% of deals. Fear of messing up beats fear of missing out.</div></div>
+                            </div>
+                            <div className="bb-body" style={{display:"flex",flexDirection:"column",gap:10}}>
+                              {[
+                                {key:"judgeIndecision",label:"J — Judge the Indecision",color:"var(--amber)",bg:"var(--amber-bg)",icon:"🔍"},
+                                {key:"recommendation",label:"O — Offer Your Recommendation",color:"var(--green)",bg:"var(--green-bg)",icon:"🎯"},
+                                {key:"limitExploration",label:"L — Limit the Exploration",color:"var(--navy)",bg:"var(--navy-bg)",icon:"🔬"},
+                                {key:"takeRiskOff",label:"T — Take Risk Off the Table",color:"var(--purple)",bg:"var(--purple-bg)",icon:"🛡"},
+                              ].map(({key,label,color,bg,icon})=>riverHypo.joltPlan[key]&&(
+                                <div key={key} style={{background:bg,border:"1px solid "+color+"33",borderRadius:8,padding:"10px 12px"}}>
+                                  <div style={{fontSize:10,fontWeight:700,color,textTransform:"uppercase",letterSpacing:"0.4px",marginBottom:4}}>{icon} {label}</div>
+                                  <EF value={riverHypo.joltPlan[key]||""} onChange={v=>setRiverHypo(prev=>({...prev,joltPlan:{...prev.joltPlan,[key]:v}}))} single/>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Talk Tracks */}
+                        {(riverHypo.talkTracks||[]).length>0&&(
+                          <div className="bb" style={{marginBottom:10}}>
+                            <div className="bb-hdr">
+                              <div className="bb-icon" style={{fontSize:14}}>💬</div>
+                              <div><div className="bb-title">Talk Tracks</div><div className="bb-sub">Stage-by-stage language — grounded in buyer experience research</div></div>
+                            </div>
+                            <div className="bb-body" style={{display:"flex",flexDirection:"column",gap:12}}>
+                              {(riverHypo.talkTracks||[]).map((t,i)=>(
+                                <div key={i} style={{borderLeft:"3px solid var(--tan-0)",paddingLeft:12}}>
+                                  <div style={{fontSize:10,fontWeight:700,color:"var(--tan-0)",textTransform:"uppercase",letterSpacing:"0.5px",marginBottom:4}}>{t.stage}</div>
+                                  <EF
+                                    value={t.line||""}
+                                    onChange={v=>setRiverHypo(prev=>{
+                                      const tt=[...(prev.talkTracks||[])];
+                                      tt[i]={...tt[i],line:v};
+                                      return {...prev,talkTracks:tt};
+                                    })}
+                                    single
+                                    placeholder="Click to edit..."
+                                  />
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </>
+                    )}
+
+                    {!riverHypo&&!riverHypoLoading&&(
+                      <EmptyState icon="🧪" title="No hypothesis yet" sub="This is where you stop winging it. A structured conversation plan, talk tracks that sound like you, and an insight that makes them lean in. Build it — then go be the most prepared person on the call." action={()=>buildRiverHypo(brief,selectedAccount)} actionLabel="Build Hypothesis →"/>
+                    )}
+
+                    {!riverHypoLoading&&riverHypo?.reality?.includes("Could not generate")&&(
+                      <div style={{marginTop:4}}>
+                        <button className="btn btn-secondary" onClick={()=>{if(!checkNoChange("hypo",getHypoSig,()=>buildRiverHypo(brief,selectedAccount)))buildRiverHypo(brief,selectedAccount);}} disabled={riverHypoLoading}>
+                          ↻ Regenerate Hypothesis
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
+                {/* ── END MERGED GAME PLAN ────────────────────────────────── */}
 
                 {(briefError || brief._error || brief._failedSections?.length > 0) && (
                   <div style={{background:"var(--amber-bg)",border:"1.5px solid var(--amber)",borderRadius:10,padding:"14px 16px",marginBottom:16}}>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14377,8 +14377,7 @@ Return ONLY raw JSON:
                       <div style={{fontSize:13,fontWeight:700,color:"var(--ink-0)",marginBottom:6}}>Let's add a little context</div>
                       <div style={{fontSize:12,color:"var(--ink-1)",lineHeight:1.6,marginBottom:12}}>
                         Looks like your company's website is a little light on product, services, solutions, and case-study content.
-                        Not a problem — use the upload button to add relevant materials (case studies, product one-pagers, etc.),
-                        or use the text field below to describe the products, solutions, or services you're focused on selling.
+                        Not a problem — use the upload button to add relevant materials (case studies, product one-pagers, etc.).
                       </div>
                       <div style={{display:"flex",gap:8,flexWrap:"wrap",alignItems:"center"}}>
                         {/* Reuses the existing docs pipeline — same input + handler as the header "+ Add Docs" (handleDocFiles @5725 → sellerDocs) */}
@@ -14387,19 +14386,12 @@ Return ONLY raw JSON:
                             onChange={e=>{handleDocFiles(e.target.files);e.target.value="";}}/>
                           📂 Upload materials
                         </label>
-                        <button className="btn btn-secondary btn-sm"
-                          onClick={()=>{
-                            setCollapsedBB(prev=>{const next=new Set(prev);next.delete("setupDetails");return next;});
-                            setTimeout(()=>{document.getElementById("kickoffv2-icp-input")?.focus();},80);
-                          }}>
-                          ✏️ Describe what you sell
-                        </button>
                         {sellerDocs.length>0&&(
                           <span style={{fontSize:11,fontWeight:600,color:"var(--green)"}}>✓ {sellerDocs.length} doc{sellerDocs.length>1?"s":""} added</span>
                         )}
                       </div>
                       <div style={{fontSize:11,color:"var(--ink-3)",marginTop:10}}>
-                        Either one works. Then continue below — you'll build your ICP on the next step with whatever you add here.
+                        Then continue below — you'll build your ICP on the next step with whatever you add here.
                       </div>
                     </div>
                   )}
@@ -14416,13 +14408,13 @@ Return ONLY raw JSON:
                 </div>
 
                 {/* Add more details — collapsed disclosure; binds the SAME state the classic form feeds
-                    into the ICP prompt (sellerStage @7754, icpTargeting @5817-5824, sellerICPInput @8270) */}
+                    into the ICP prompt (sellerStage @7754, icpTargeting @5817-5824) */}
                 <div style={{marginTop:14}}>
                   <div onClick={()=>toggleBB("setupDetails")} style={{cursor:"pointer",display:"flex",alignItems:"center",gap:8,padding:"8px 12px",background:"var(--bg-1)",borderRadius:8,border:"1px solid var(--line-0)"}}>
                     <span style={{fontSize:13}}>{bbIsOpen("setupDetails")?"▾":"▸"}</span>
                     <div style={{flex:1}}>
                       <div style={{fontSize:12,fontWeight:700,color:"var(--ink-1)"}}>Add more details <span style={{fontWeight:400,color:"var(--ink-3)"}}>(optional — improves targeting)</span></div>
-                      <div style={{fontSize:10,color:"var(--ink-3)"}}>Funding stage, market segment, your own ICP notes</div>
+                      <div style={{fontSize:10,color:"var(--ink-3)"}}>Funding stage, market segment</div>
                     </div>
                     {sellerStage && <span style={{fontSize:10,fontWeight:700,background:"var(--green-bg)",color:"var(--green)",borderRadius:10,padding:"2px 8px"}}>{sellerStage}</span>}
                   </div>
@@ -14450,16 +14442,6 @@ Return ONLY raw JSON:
                               border:"1.5px solid "+(sel?"var(--navy)":"var(--line-0)"),background:sel?"var(--navy)":"var(--surface)",color:sel?"#fff":"var(--ink-1)"}}>{v}</button>;
                         })}
                       </div>
-                    </div>
-                    <div>
-                      <div style={{fontSize:11,fontWeight:600,color:"var(--ink-2)",marginBottom:4}}>Anything else we should know? <span style={{fontWeight:400,color:"var(--ink-3)"}}>your ICP, in your own words</span></div>
-                      <textarea
-                        id="kickoffv2-icp-input"
-                        value={sellerICPInput}
-                        onChange={e=>setSellerICPInput(e.target.value)}
-                        placeholder={"e.g. \"We sell to SMB restaurants with 1-5 locations, owner-operators, $500K-$5M revenue\""}
-                        style={{width:"100%",minHeight:60,padding:"10px 12px",fontSize:13,border:"1.5px solid var(--line-0)",borderRadius:8,resize:"vertical",fontFamily:"inherit",lineHeight:1.6,background:"var(--bg-0)"}}
-                      />
                     </div>
                   </div>
                 </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import { OUTCOMES } from "./data/outcomes.js";
 import { RIVER_STAGES } from "./data/riverFramework.js";
 import { SAMPLE_ROWS } from "./data/sampleAccounts.js";
 import { sbAuth, sbGetUser, sbSessions, sbStoreTokens, sbRestoreSession, sbRefreshSession, sbClearTokens, sbSetTokenCallback, sbUpdateUserMetadata } from "./lib/supabase.js";
-import { fetchOrgContext, sbPatch } from "./lib/org.js";
+import { fetchOrgContext, sbPatch, sbRpc } from "./lib/org.js";
 import SuperAdmin from "./components/SuperAdmin.jsx";
 import UserDashboard from "./components/UserDashboard.jsx";
 import S9SolutionFit from "./stages/S9_SolutionFit.jsx";
@@ -5606,6 +5606,7 @@ export default function App(){
   const[icpDelta,setIcpDelta]=useState(null); // {alignments:[], gaps:[], recommendations:[]}
   const[icpDeltaLoading,setIcpDeltaLoading]=useState(false);
   const[orgCtx,setOrgCtx]=useState(null); // {id, name, run_count, run_limit, plan, userRole, ...}
+  const[promoOffer,setPromoOffer]=useState(null); // 'run_pack' | 'monthly' | null — which promo card this org gets (promo_offer_kind RPC, migration 037)
   const[upgradeOpen,setUpgradeOpen]=useState(false); // show upgrade prompt modal
   const[contactFormOpen,setContactFormOpen]=useState(false);
   const[contactFormMsg,setContactFormMsg]=useState("");
@@ -13459,6 +13460,17 @@ Return ONLY raw JSON:
   // Refresh orgCtx after billable calls to keep token count accurate
   const refreshOrgCtx = () => { if (sbUser?.id && sbToken) fetchOrgContext(sbUser.id, sbToken).then(org => { if (org) setOrgCtx(org); }); };
 
+  // Which promo offer card the pricing modal shows. grants_run_pack lives in the
+  // service-role-only promo_codes table, so the client asks the promo_offer_kind()
+  // RPC (migration 037) instead of deciding from orgCtx alone — otherwise orgs
+  // admitted by a non-pack code would see a Run Pack button /api/checkout rejects.
+  React.useEffect(() => {
+    if (!sbToken || !orgCtx?.promo_code) { setPromoOffer(null); return; }
+    sbRpc("promo_offer_kind", sbToken, {})
+      .then(kind => setPromoOffer(kind === "run_pack" || kind === "monthly" ? kind : null))
+      .catch(() => setPromoOffer(null));
+  }, [sbToken, orgCtx?.promo_code, orgCtx?.plan]);
+
   // Auto-populate seller URL from org context on new sessions
   // so users don't have to re-enter their company every time.
   // Pre-fills the field and sets sellerUrl, but does NOT auto-trigger
@@ -13487,7 +13499,7 @@ Return ONLY raw JSON:
       // knowledge, compliance, battle cards, etc. Without this, the cached
       // trial-tier layers would persist until the 5-min cache expires.
       setTimeout(fetchKnowledgeLayer, 2500);
-      setChatMessages(prev => [...prev, { role: "assistant", content: plan === "promo_pack" ? "Your 20-run pack is active — the runs are already on your account. Let's go close some deals." : `Welcome to the ${plan.charAt(0).toUpperCase()+plan.slice(1)} plan! Your runs have been upgraded. Let's go close some deals.` }]);
+      setChatMessages(prev => [...prev, { role: "assistant", content: plan === "promo_pack" ? "Your 20-run pack is active — the runs are already on your account. Let's go close some deals." : plan === "promo_monthly" ? "Your promo plan is active — 20 runs a month for 2 months, then you'll graduate to Starter automatically. Let's go close some deals." : `Welcome to the ${plan.charAt(0).toUpperCase()+plan.slice(1)} plan! Your runs have been upgraded. Let's go close some deals.` }]);
       setChatOpen(true);
     } else if (checkout === "cancel") {
       window.history.replaceState({}, "", window.location.pathname);
@@ -20308,8 +20320,8 @@ Return ONLY raw JSON:
 
             {/* Pricing cards */}
             <div style={{padding:"20px 24px",display:"grid",gridTemplateColumns:"repeat(auto-fit, minmax(145px, 1fr))",gap:10}}>
-              {/* One-time run pack — only for orgs admitted via a promo code, still on trial (or topping up a prior pack). Eligibility is re-verified server-side in /api/checkout. */}
-              {sbUser&&orgCtx?.promo_code&&(orgCtx?.plan==="trial"||orgCtx?.plan==="promo")&&(
+              {/* One-time run pack — only for orgs whose admitting promo code grants it (promo_offer_kind RPC). Eligibility is re-verified server-side in /api/checkout. */}
+              {sbUser&&promoOffer==="run_pack"&&(
                 <div style={{border:"2px solid var(--green)",borderRadius:10,padding:"18px 16px",position:"relative",background:"var(--surface)"}}>
                   <div style={{position:"absolute",top:-10,left:"50%",transform:"translateX(-50%)",fontSize:10,fontWeight:700,padding:"2px 10px",borderRadius:20,background:"var(--green)",color:"var(--surface)",textTransform:"uppercase",letterSpacing:"0.5px",whiteSpace:"nowrap"}}>Your Offer</div>
                   <div style={{fontSize:14,fontWeight:700,color:"var(--ink-0)",marginBottom:4}}>Run Pack</div>
@@ -20334,6 +20346,35 @@ Return ONLY raw JSON:
                   }}
                     style={{display:"block",width:"100%",textAlign:"center",padding:"10px",borderRadius:8,background:"var(--green)",color:"var(--surface)",fontSize:12,fontWeight:700,border:"none",cursor:"pointer",marginTop:12,fontFamily:"var(--font-sans)"}}>
                     Get 20 runs →
+                  </button>
+                </div>
+              )}
+              {/* $45/mo promo subscription (issue #143) — promo-code trial orgs whose code doesn't grant the run pack. 2 billing cycles, then Stripe's subscription schedule graduates the org to Starter. Eligibility is re-verified server-side in /api/checkout. */}
+              {sbUser&&promoOffer==="monthly"&&(
+                <div style={{border:"2px solid var(--green)",borderRadius:10,padding:"18px 16px",position:"relative",background:"var(--surface)"}}>
+                  <div style={{position:"absolute",top:-10,left:"50%",transform:"translateX(-50%)",fontSize:10,fontWeight:700,padding:"2px 10px",borderRadius:20,background:"var(--green)",color:"var(--surface)",textTransform:"uppercase",letterSpacing:"0.5px",whiteSpace:"nowrap"}}>Your Offer</div>
+                  <div style={{fontSize:14,fontWeight:700,color:"var(--ink-0)",marginBottom:4}}>Promo Plan</div>
+                  <div style={{display:"flex",alignItems:"baseline",gap:2,marginBottom:2}}>
+                    <span style={{fontSize:32,fontWeight:700,color:"var(--ink-0)",fontFamily:"'Crimson Pro',serif"}}>$45</span>
+                    <span style={{fontSize:12,color:"var(--ink-3)"}}>/mo</span>
+                  </div>
+                  <div style={{fontSize:11,color:"var(--tan-0)",fontWeight:600,marginBottom:2}}>20 runs / month</div>
+                  <div style={{fontSize:11,color:"var(--ink-3)",marginBottom:10}}>Exclusive {orgCtx.promo_code} offer — 2 months, then Starter at $99/mo</div>
+                  {["Full ICP + brief pipeline","RIVER hypothesis + discovery","Milton coaching","Paid-tier knowledge layers"].map(f=>(
+                    <div key={f} style={{fontSize:11,color:"var(--ink-1)",padding:"2px 0",display:"flex",gap:6}}>
+                      <span style={{color:"var(--green)",flexShrink:0}}>✓</span>{f}
+                    </div>
+                  ))}
+                  <button onClick={async()=>{
+                    try{
+                      const r=await apiFetch("/api/checkout",{method:"POST",headers:{"Content-Type":"application/json",Authorization:`Bearer ${sbToken}`},body:JSON.stringify({planId:"promo_monthly"})});
+                      const d=await r.json();
+                      if(d.url)window.location.href=d.url;
+                      else alert(d.error||"Checkout failed — please try again.");
+                    }catch{alert("Failed to start checkout — check your connection.");}
+                  }}
+                    style={{display:"block",width:"100%",textAlign:"center",padding:"10px",borderRadius:8,background:"var(--green)",color:"var(--surface)",fontSize:12,fontWeight:700,border:"none",cursor:"pointer",marginTop:12,fontFamily:"var(--font-sans)"}}>
+                    Start promo plan →
                   </button>
                 </div>
               )}

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -2,5 +2,10 @@ export const ANTHROPIC_MODEL_SONNET = "claude-sonnet-4-6";
 export const ANTHROPIC_MODEL_HAIKU = "claude-haiku-4-5-20251001";
 export const COHORT_COLORS = ["#8B6F47","#4A7A9B","#6B8E6B","#9B6B8E","#7A7A4A","#C87533","#1B3A6B","#2E6B2E","#9B2C2C","#6B3A7A","#BA7517","#3A6B6B","#6B4A9B","#A84A4A","#4A9B7A"];
 export const MAX_OUTCOMES = 3;
+// Feature flag (issue #28): merge the Game Plan step into the Brief's Play card.
+// OFF (false) = current behavior — 9 visible steps, Game Plan step unchanged.
+// Flip to true only after staging sign-off. localStorage "cc_merged_play"
+// ("on"/"off") overrides this default for per-browser staging QA.
+export const MERGED_PLAY = false;
 export const MAX_DOCS = 6;
 export const MAX_PRODUCTS = 20;

--- a/supabase/migrations/036_promo_monthly_plan.sql
+++ b/supabase/migrations/036_promo_monthly_plan.sql
@@ -1,0 +1,64 @@
+-- Migration 036: Promo monthly plan — 10 free → $45/mo × 2 months → starter (issue #137)
+--
+-- Adds the promo_monthly plan value, two columns for Stripe subscription tracking and
+-- UI display, and updates process_monthly_rollover so promo_monthly orgs receive the
+-- same rollover mechanics as paid orgs.
+--
+-- Run order: after 035. Additive and IF NOT EXISTS-safe (staging shares prod DB).
+-- Stripe setup required before first checkout: create a $45/mo recurring price in the
+-- Stripe dashboard and set STRIPE_PRICE_PROMO_MONTHLY in Vercel env vars.
+
+-- ── 1. Extend plan constraint ────────────────────────────────────────────────
+-- Add promo_monthly alongside the existing values. DROP+ADD is the only way to
+-- alter a CHECK constraint in Postgres (same pattern as migration 034).
+ALTER TABLE public.orgs DROP CONSTRAINT IF EXISTS orgs_plan_check;
+ALTER TABLE public.orgs ADD CONSTRAINT orgs_plan_check
+  CHECK (plan IN ('trial', 'paid', 'suspended', 'promo', 'promo_monthly'));
+
+-- ── 2. New columns ────────────────────────────────────────────────────────────
+-- The Stripe subscription ID, stored at checkout completion, is needed to:
+-- (a) verify the subscription schedule was attached correctly,
+-- (b) surface a "manage subscription" link in the UI (future), and
+-- (c) allow manual graduation if the Stripe schedule ever fails.
+ALTER TABLE public.orgs ADD COLUMN IF NOT EXISTS stripe_subscription_id text;
+
+-- Approximate end of the promo period — stored for UI display (e.g. "Your promo
+-- rate ends on Oct 3, 2026"). The actual graduation is driven by Stripe's
+-- subscription schedule; this column is informational only and is cleared on
+-- graduation via the stripe-webhook handler.
+ALTER TABLE public.orgs ADD COLUMN IF NOT EXISTS promo_period_end timestamptz;
+
+-- ── 3. Monthly rollover — include promo_monthly alongside paid ───────────────
+-- Migration 034 redefined this RPC to process only plan='paid'. Now extend it to
+-- also process plan='promo_monthly': same rollover mechanics, same caps.
+-- promo orgs (old one-time pack) are intentionally excluded — their run_count is
+-- monotonic by design (the pack is a one-time allotment, not a monthly renewal).
+CREATE OR REPLACE FUNCTION public.process_monthly_rollover()
+RETURNS jsonb AS $$
+DECLARE
+  v_org record;
+  v_count int := 0;
+BEGIN
+  FOR v_org IN
+    SELECT id, run_count, run_limit, rollover_runs, rollover_cap
+    FROM public.orgs
+    WHERE plan IN ('paid', 'promo_monthly')
+    FOR UPDATE
+  LOOP
+    DECLARE
+      v_total_available int := v_org.run_limit + v_org.rollover_runs;
+      v_unused int := GREATEST(0, v_total_available - v_org.run_count);
+      v_new_rollover int := LEAST(v_unused, v_org.rollover_cap);
+    BEGIN
+      UPDATE public.orgs
+      SET run_count = 0,
+          rollover_runs = v_new_rollover,
+          updated_at = now()
+      WHERE id = v_org.id;
+      v_count := v_count + 1;
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object('ok', true, 'orgs_processed', v_count);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/migrations/037_promo_offer_kind_rpc.sql
+++ b/supabase/migrations/037_promo_offer_kind_rpc.sql
@@ -1,0 +1,33 @@
+-- Migration 037: promo_offer_kind() RPC — which promo offer the caller's org gets (issue #143)
+--
+-- The pricing modal needs to know whether to render the one-time Run Pack card
+-- (issue #2) or the $45/mo promo-monthly card (issue #137). That depends on
+-- promo_codes.grants_run_pack, but promo_codes is service-role only (RLS on, no
+-- policies), so the client can't read it. This SECURITY DEFINER function exposes
+-- exactly one bit for the caller's own org and nothing else — no code text, no
+-- use counts, not queryable for arbitrary codes.
+--
+-- Returns:
+--   'run_pack' — org admitted by an active code with grants_run_pack, still on
+--                trial or promo (matches the pack eligibility in api/checkout.js)
+--   'monthly'  — org admitted by any other active code, still on trial
+--                (matches the promo_monthly eligibility in api/checkout.js)
+--   NULL       — no promo offer for this org
+--
+-- Run order: after 036. Additive; safe to re-run.
+
+CREATE OR REPLACE FUNCTION public.promo_offer_kind()
+RETURNS text AS $$
+  SELECT CASE
+    WHEN pc.grants_run_pack AND o.plan IN ('trial', 'promo') THEN 'run_pack'
+    WHEN NOT pc.grants_run_pack AND o.plan = 'trial' THEN 'monthly'
+    ELSE NULL
+  END
+  FROM public.users u
+  JOIN public.orgs o ON o.id = u.org_id
+  JOIN public.promo_codes pc ON pc.code = o.promo_code AND pc.active
+  WHERE u.id = auth.uid()::text
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+REVOKE ALL ON FUNCTION public.promo_offer_kind() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.promo_offer_kind() TO authenticated;


### PR DESCRIPTION
Production flip of the current staging batch. Rollback tag: `main-pre-promo-plan`.

Ships:
- **#137 / #143** — promo monthly plan, end to end: 10 free runs at promo signup, $45/mo × 2 cycles checkout (`promo_monthly`), Stripe subscription schedule auto-graduating to Starter, pricing-modal offer card gated by the `promo_offer_kind()` RPC, Run Pack card no longer shown to ineligible orgs. Migrations 036/037 already applied to the prod database; `STRIPE_PRICE_PROMO_MONTHLY` already set in Vercel Production.
- **#28** — game-plan merge: `mergedPlay` flag, The Play absorbs solution architecture + hypothesis, Game Plan step retired from stepper, kickoff context consolidation.
- **#27** — speed: prompt-cache the static prefix on the Claude proxy path, p50/p95 health check from `api_usage_log`.
- **#29** — scan depth: Firecrawl direct page-probe fallback, single context affordance on the light path.