### PR TITLE
feat: admin plan controls understand promo plans (#146)

### DIFF
--- a/api/_admin-action.js
+++ b/api/_admin-action.js
@@ -167,7 +167,7 @@ export default async function handler(req, res) {
     if (action === "update_org") {
       const { orgId, fields } = req.body || {};
       if (!orgId || !fields) return res.status(400).json({ error: "orgId and fields required" });
-      const allowed = ["name", "seller_url", "plan", "run_limit", "max_run_limit", "run_count", "max_run_count"];
+      const allowed = ["name", "seller_url", "plan", "run_limit", "max_run_limit", "run_count", "max_run_count", "rollover_cap"];
       const patch = {};
       for (const k of allowed) { if (k in fields) patch[k] = fields[k]; }
       if (!Object.keys(patch).length) return res.status(400).json({ error: "No valid fields" });
@@ -178,8 +178,13 @@ export default async function handler(req, res) {
       }
       // Sanitize string fields against XSS
       if (patch.name) patch.name = String(patch.name).replace(/<[^>]*>/g, "").slice(0, 200);
-      // DB constraint only allows trial/paid/suspended — map tier names
-      if (patch.plan && !["trial", "paid", "suspended"].includes(patch.plan)) patch.plan = "paid";
+      // DB constraint allows trial/paid/suspended/promo/promo_monthly (migration 036) —
+      // pass those through, map tier names (starter/pro/team/enterprise) to 'paid'
+      if (patch.plan && !["trial", "paid", "suspended", "promo", "promo_monthly"].includes(patch.plan)) patch.plan = "paid";
+      // Admin-set promo_monthly is a manual comp — no Stripe subscription/schedule, so no
+      // auto-graduation. Stamp the informational period end; clear it on any other plan.
+      if (patch.plan === "promo_monthly") patch.promo_period_end = new Date(Date.now() + 60 * 24 * 3600 * 1000).toISOString();
+      else if (patch.plan) patch.promo_period_end = null;
 
       const r = await fetch(`${SB_URL}/rest/v1/orgs?id=eq.${orgId}`, {
         method: "PATCH",
@@ -194,8 +199,8 @@ export default async function handler(req, res) {
     if (action === "create_org") {
       const { orgData } = req.body || {};
       if (!orgData?.name) return res.status(400).json({ error: "Org name required" });
-      // DB constraint only allows trial/paid/suspended — map tier names to 'paid'
-      if (orgData.plan && !["trial", "paid", "suspended"].includes(orgData.plan)) orgData.plan = "paid";
+      // DB constraint allows trial/paid/suspended/promo/promo_monthly — map tier names to 'paid'
+      if (orgData.plan && !["trial", "paid", "suspended", "promo", "promo_monthly"].includes(orgData.plan)) orgData.plan = "paid";
       const r = await fetch(`${SB_URL}/rest/v1/orgs`, {
         method: "POST",
         headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}`, "Content-Type": "application/json", Prefer: "return=representation" },

--- a/src/components/SuperAdmin.jsx
+++ b/src/components/SuperAdmin.jsx
@@ -34,6 +34,8 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
     { id: "pro", name: "Pro", tokens: 100, maxTokens: 20, price: 349, costPerToken: 1.16 },
     { id: "team", name: "Team", tokens: 250, maxTokens: 50, price: 799, costPerToken: 1.16 },
     { id: "enterprise", name: "Enterprise", tokens: 1000, maxTokens: 200, price: 2500, costPerToken: 1.16 },
+    // promo: true keeps the $45 comp plan out of the revenue projections' averages
+    { id: "promo_monthly", name: "Promo Monthly", tokens: 20, maxTokens: 0, price: 45, costPerToken: 1.16, promo: true },
   ]);
   const [planSaveMsg, setPlanSaveMsg] = useState("");
   // ── GLOBAL FILTERS ──
@@ -235,13 +237,15 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
   const applyPlanToOrg = async (orgId, planId) => {
     const plan = plans.find(p => p.id === planId);
     if (!plan) return;
+    // Through /api/admin so the service role applies it and tier names map to legal
+    // DB plan values — a direct PATCH with plan:'starter' violates orgs_plan_check.
     try {
-      await fetch(`${SB_URL}/rest/v1/orgs?id=eq.${orgId}`, {
-        method: "PATCH",
-        headers: { apikey: SB_KEY, Authorization: `Bearer ${sbToken}`, "Content-Type": "application/json", Prefer: "return=minimal" },
-        body: JSON.stringify({ plan: plan.id, run_limit: plan.tokens, max_run_limit: plan.maxTokens }),
+      const r = await apiFetch("/api/admin", {
+        method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
+        body: JSON.stringify({ action: "update_org", orgId, email: "org", fields: { plan: plan.id, run_limit: plan.tokens, max_run_limit: plan.maxTokens, rollover_cap: plan.price > 0 ? plan.tokens : 0 } }),
       });
-      setPlanSaveMsg(`Applied "${plan.name}" to org ${orgId}`);
+      const d = await r.json();
+      setPlanSaveMsg(d.ok ? `Applied "${plan.name}" to org ${orgId}` : `Error: ${d.error || "Failed to apply plan"}`);
       setTimeout(() => setPlanSaveMsg(""), 3000);
     } catch { setPlanSaveMsg("Error applying plan"); }
   };
@@ -332,6 +336,8 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
             <option value="">Any plan</option>
             <option value="trial">Trial</option>
             <option value="paid">Paid</option>
+            <option value="promo_monthly">Promo Monthly</option>
+            <option value="promo">Promo (run pack)</option>
             <option value="enterprise">Enterprise</option>
             <option value="suspended">Suspended</option>
           </select>
@@ -355,6 +361,8 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
             <option value="">Any plan</option>
             <option value="trial">Trial</option>
             <option value="paid">Paid</option>
+            <option value="promo_monthly">Promo Monthly</option>
+            <option value="promo">Promo (run pack)</option>
             <option value="enterprise">Enterprise</option>
             <option value="suspended">Suspended</option>
           </select>
@@ -1356,12 +1364,12 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                               </td>
                               <td>
                                 {(() => {
-                                  const pm = { trial: { bg: "var(--amber-bg)", border: "var(--amber)" }, starter: { bg: "var(--green-bg)", border: "var(--green)" }, pro: { bg: "var(--green-bg)", border: "var(--green)" }, team: { bg: "var(--navy-bg)", border: "var(--navy)" }, enterprise: { bg: "var(--violet-bg)", border: "var(--violet)" }, paid: { bg: "var(--green-bg)", border: "var(--green)" }, suspended: { bg: "var(--red-bg)", border: "var(--red)" } };
+                                  const pm = { trial: { bg: "var(--amber-bg)", border: "var(--amber)" }, starter: { bg: "var(--green-bg)", border: "var(--green)" }, pro: { bg: "var(--green-bg)", border: "var(--green)" }, team: { bg: "var(--navy-bg)", border: "var(--navy)" }, enterprise: { bg: "var(--violet-bg)", border: "var(--violet)" }, paid: { bg: "var(--green-bg)", border: "var(--green)" }, promo: { bg: "var(--green-bg)", border: "var(--green)" }, promo_monthly: { bg: "var(--green-bg)", border: "var(--green)" }, suspended: { bg: "var(--red-bg)", border: "var(--red)" } };
                                   const ps = pm[o.plan] || pm.trial;
                                   return (
                                 <select defaultValue={o.plan} onChange={e => {
                                   const plan = e.target.value;
-                                  const limits = { trial: { run_limit: 3, max_run_limit: 0 }, starter: { run_limit: 25, max_run_limit: 5 }, pro: { run_limit: 100, max_run_limit: 20 }, team: { run_limit: 250, max_run_limit: 50 }, enterprise: { run_limit: 1000, max_run_limit: 200 } };
+                                  const limits = { trial: { run_limit: 3, max_run_limit: 0 }, starter: { run_limit: 25, max_run_limit: 5, rollover_cap: 25 }, pro: { run_limit: 100, max_run_limit: 20, rollover_cap: 100 }, team: { run_limit: 250, max_run_limit: 50, rollover_cap: 250 }, enterprise: { run_limit: 1000, max_run_limit: 200, rollover_cap: 1000 }, promo_monthly: { run_limit: 20, max_run_limit: 0, rollover_cap: 20 } };
                                   patchOrg({ plan, ...(limits[plan] || {}) }, `${o.name} \u2192 ${plan}${limits[plan]?.run_limit ? ` (${limits[plan].run_limit} runs)` : ""}`);
                                 }} style={{ background: ps.bg, borderColor: ps.border, color: ps.border, fontWeight: 700 }}>
                                   <option value="trial">Trial</option>
@@ -1370,6 +1378,9 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                                   <option value="team">Team</option>
                                   <option value="enterprise">Enterprise</option>
                                   <option value="paid">Paid</option>
+                                  {/* Manual comp \u2014 no Stripe subscription/schedule behind it, so no auto-graduation (issue #146) */}
+                                  <option value="promo_monthly">Promo Monthly ($45)</option>
+                                  <option value="promo">Promo (run pack)</option>
                                   <option value="suspended">Suspended</option>
                                 </select>
                                   );
@@ -1914,8 +1925,9 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
               <div style={{ background: "var(--bg-1)", borderRadius: 10, padding: "16px 18px" }}>
                 <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 12 }}>
                   {[10, 25, 50, 100].map(users => {
-                    const avgPrice = plans.filter(p => p.price > 0).reduce((s, p) => s + p.price, 0) / plans.filter(p => p.price > 0).length;
-                    const avgCost = plans.filter(p => p.price > 0).reduce((s, p) => s + p.tokens * p.costPerToken, 0) / plans.filter(p => p.price > 0).length;
+                    const projectable = plans.filter(p => p.price > 0 && !p.promo);
+                    const avgPrice = projectable.reduce((s, p) => s + p.price, 0) / projectable.length;
+                    const avgCost = projectable.reduce((s, p) => s + p.tokens * p.costPerToken, 0) / projectable.length;
                     const mrr = Math.round(users * avgPrice * 0.6); // assume 60% on avg paid plan
                     const cost = Math.round(users * avgCost * 0.6);
                     return (


### PR DESCRIPTION
Closes #146.

Admin user-administration updates so promo plans can be set and displayed:

- **Org-table plan dropdown**: new "Promo Monthly ($45)" and "Promo (run pack)" options (20 runs / rollover 20 for monthly), plus badge colors — promo orgs previously fell back to displaying "Trial". Paid tiers now also send `rollover_cap` matching the webhook's values.
- **Plan filters** (users + orgs tabs) gain the promo options.
- **`api/_admin-action.js`**: `promo`/`promo_monthly` pass through the plan whitelist instead of being coerced to `paid`; `rollover_cap` allowed; admin-set `promo_monthly` stamps `promo_period_end` (+60d) and any other plan clears it. An admin-set promo_monthly is a manual comp — there's no Stripe subscription/schedule behind it, so it never auto-graduates; graduation for comps is manual (flip to Starter later).
- **Pricing-tab "Apply Plan to Organization"** now routes through `/api/admin update_org` — the old direct Supabase PATCH sent tier names that violate `orgs_plan_check` and reported success unconditionally. Errors now surface.
- Revenue projections exclude the $45 comp plan from tier averages.

Verified: build passes; eslint problem count on both files unchanged (6 pre-existing).