### PR TITLE
release: promo funnel for all trials (#151)

### DIFF
--- a/api/_provision.js
+++ b/api/_provision.js
@@ -109,15 +109,14 @@ export async function provisionTrialAccess({ email, name, company, invitedBy = "
     return { ok: true, orgId: pending[0].org_id, invitationId: pending[0].id, emailSent, action: `resent_${action}` };
   }
 
-  // Fresh trial org (plan/run limits come from column defaults, as in
-  // _usage.js). The admitting promo code is stamped on the org — checkout
+  // Fresh trial org. The admitting promo code is stamped on the org — checkout
   // verifies run-pack eligibility against it (migration 034). Conditional so
   // non-promo callers (issue #3 admin approval) never touch the column.
-  // Promo-code signups get 10 free runs (vs. the default 3 for standard trial)
-  // so they can evaluate the product before the $45/mo promo subscription (issue #137).
+  // Every new trial gets 10 free runs — the promo funnel (10 free → $45/mo half-off
+  // → Starter) applies to all signups, promo code or not (issue #151).
   const orgName = (company || name || cleanEmail).trim();
   const created = await sbFetch("orgs", "POST",
-    promoCode ? { name: orgName, promo_code: promoCode, run_limit: 10 } : { name: orgName });
+    promoCode ? { name: orgName, promo_code: promoCode, run_limit: 10 } : { name: orgName, run_limit: 10 });
   const orgId = Array.isArray(created) ? created[0]?.id : created?.id;
   if (!orgId) {
     console.warn("[provision] Org creation failed:", JSON.stringify(created));

--- a/api/checkout.js
+++ b/api/checkout.js
@@ -125,11 +125,13 @@ export default async function handler(req, res) {
   if (isPromoMonthly) {
     try {
       if (!orgId) return res.status(403).json({ error: "This offer isn't available for your account" });
-      const orgRes = await fetch(`${SB_URL}/rest/v1/orgs?id=eq.${orgId}&select=promo_code,plan`, {
+      const orgRes = await fetch(`${SB_URL}/rest/v1/orgs?id=eq.${orgId}&select=plan`, {
         headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}` },
       });
       const org = (await orgRes.json())?.[0];
-      const eligible = org?.promo_code && org.plan === "trial";
+      // Any trial org qualifies — the promo funnel is the default new-user path,
+      // no promo code required (issue #151).
+      const eligible = org?.plan === "trial";
       if (!eligible) return res.status(403).json({ error: "This offer isn't available for your account" });
     } catch (e) {
       console.error("[checkout] Promo monthly eligibility check failed:", e.message);

--- a/api/cron-reset-tokens.js
+++ b/api/cron-reset-tokens.js
@@ -59,19 +59,12 @@ export default async function handler(req, res) {
       body: JSON.stringify({ max_run_count: 0 }),
     });
 
-    // Step 2: Reset trial orgs (no rollover, just zero out)
-    const trialRes = await fetch(`${SB_URL}/rest/v1/orgs?plan=eq.trial&run_count=gt.0`, {
-      method: "PATCH",
-      headers: {
-        apikey: SB_KEY,
-        Authorization: `Bearer ${SB_KEY}`,
-        "Content-Type": "application/json",
-        Prefer: "return=representation",
-      },
-      body: JSON.stringify({ run_count: 0, max_run_count: 0, rollover_runs: 0 }),
-    });
-    const trialUpdated = await trialRes.json();
-    const trialCount = Array.isArray(trialUpdated) ? trialUpdated.length : 0;
+    // Step 2: Trial orgs are NOT reset. The 10 free runs are a one-time
+    // allotment in the promo funnel (10 free → $45/mo half-off → Starter,
+    // issue #151) — resetting monthly would hand out fresh free runs forever
+    // and remove the reason to convert at run 11. Trial run_count is monotonic,
+    // same as the old one-time run pack.
+    const trialCount = 0;
 
     // Step 3: Reset referral bonus counters (monthly cap resets)
     await fetch(`${SB_URL}/rest/v1/orgs?referral_bonus_runs=gt.0`, {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5208,7 +5208,7 @@ const APP_GUIDES = {
     subtitle: "Complete walkthrough of the 9-step sales intelligence workflow",
     icon: "📘",
     sections: [
-      { h: "Getting Started", body: "Sign up at cambree.ai. 3 free runs, no credit card. Each run takes you through the full 9-step workflow." },
+      { h: "Getting Started", body: "Sign up at cambree.ai. 10 free runs, no credit card. Each run takes you through the full 9-step workflow." },
       { h: "Step 0: Start", body: "Sets up your selling identity — who you are, what you sell, and what proof you have.\n\n1. Enter your company URL (e.g., yourcompany.com)\n2. Cambree researches your company and auto-builds your Ideal Customer Profile\n3. Upload sales materials (PDFs, decks, one-pagers) to ground AI output in YOUR proof\n4. Add proof points (ROI metrics, awards, customer wins) — cited in every brief\n5. Select your funding stage — this calibrates how the tool positions you\n\nTip: Use a URL, not just a company name — URLs give the best results." },
       { h: "Step 1: ICP & RFPs", body: "Shows your auto-generated Ideal Customer Profile — industries, buyer personas, pain points, conferences, and RFP opportunities.\n\n• Review every field — click any text to edit it\n• Your corrections override AI content in all downstream output\n• Switch to \"RFP Intel\" tab for matching procurement opportunities\n• Adjust Fit Scoring Weights to prioritize different dimensions\n\nTip: Edit the Industries list if the AI picked wrong verticals — this directly affects which companies get matched." },
       { h: "Step 2: Import", body: "Three ways to add target companies:\n\n• Upload CSV/Excel — columns auto-map (Company, Industry, URL, Employees, Ownership)\n• Quick Entry — type company names one per line\n• Build Target Accounts — AI generates 25-30 ICP-matched companies with industry, headcount, and revenue filters\n\nAll imported companies are automatically scored for ICP fit." },
@@ -5230,7 +5230,7 @@ const APP_GUIDES = {
     icon: "📙",
     sections: [
       { h: "User Management", body: "Invite: Settings → Team → Invite Member → enter email + role.\n\nRoles:\n• Rep — run briefs, save sessions, push to HubSpot\n• Manager — Rep + view team sessions and reporting\n• Admin — Manager + invite/remove members, change org settings\n\nChange role: Team → click role dropdown → select new role.\nRemove: Team → \"...\" → Remove. Sessions remain in the org." },
-      { h: "Organization Setup", body: "Seller URL: Settings → Account → enter your company URL. Triggers ICP generation.\n\nPlans:\n• Trial: 3 free runs, no credit card\n• Starter ($99/mo): 25 runs\n• Pro ($349/mo): 100 runs\n• Team ($799/mo): 250 runs\n• Enterprise ($2,500/mo): 1,000 runs\n\nRollover: Unused runs carry forward (capped at 1 month's allocation)." },
+      { h: "Organization Setup", body: "Seller URL: Settings → Account → enter your company URL. Triggers ICP generation.\n\nPlans:\n• Trial: 10 free runs, no credit card\n• Promo ($45/mo): 20 runs, first 2 months half off, then Starter\n• Starter ($99/mo): 25 runs\n• Pro ($349/mo): 100 runs\n• Team ($799/mo): 250 runs\n• Enterprise ($2,500/mo): 1,000 runs\n\nRollover: Unused runs carry forward (capped at 1 month's allocation)." },
       { h: "HubSpot Setup", body: "Settings → HubSpot → Connect. Must be logged into HubSpot in the same browser first.\n\nAfter connecting, \"Push to HubSpot\" appears in brief and post-call action bars.\n\nIf push fails: Disconnect → Reconnect in Settings." },
       { h: "Troubleshooting — ICP", body: "ICP not building?\n1. Check the URL — use a full domain like company.com\n2. Try with .com — some TLDs don't resolve\n3. Click \"Regenerate ICP\" to force fresh build\n4. Check console (DevTools → Console) for errors\n5. Check run limit — 0 remaining = ICP won't build" },
       { h: "Troubleshooting — Briefs", body: "Sections blank?\n1. Look for amber banner — \"X sections incomplete\"\n2. Hit Regenerate — free, doesn't count against runs\n3. Some sections (P3 Strategy with Opus) take 15-30 seconds\n4. Check console for specific failures" },
@@ -13462,14 +13462,14 @@ Return ONLY raw JSON:
 
   // Which promo offer card the pricing modal shows. grants_run_pack lives in the
   // service-role-only promo_codes table, so the client asks the promo_offer_kind()
-  // RPC (migration 037) instead of deciding from orgCtx alone — otherwise orgs
-  // admitted by a non-pack code would see a Run Pack button /api/checkout rejects.
+  // RPC (migration 038) instead of deciding from orgCtx alone. Any trial org can
+  // qualify for the monthly offer — no promo code required (issue #151).
   React.useEffect(() => {
-    if (!sbToken || !orgCtx?.promo_code) { setPromoOffer(null); return; }
+    if (!sbToken || !orgCtx?.id) { setPromoOffer(null); return; }
     sbRpc("promo_offer_kind", sbToken, {})
       .then(kind => setPromoOffer(kind === "run_pack" || kind === "monthly" ? kind : null))
       .catch(() => setPromoOffer(null));
-  }, [sbToken, orgCtx?.promo_code, orgCtx?.plan]);
+  }, [sbToken, orgCtx?.id, orgCtx?.promo_code, orgCtx?.plan]);
 
   // Auto-populate seller URL from org context on new sessions
   // so users don't have to re-enter their company every time.
@@ -14648,7 +14648,7 @@ Return ONLY raw JSON:
                       </div>
                     ))}
                   </div>
-                  <div style={{fontSize:12,color:"var(--ink-3)",marginBottom:8}}>3 free runs, no credit card required</div>
+                  <div style={{fontSize:12,color:"var(--ink-3)",marginBottom:8}}>10 free runs, no credit card required</div>
                 </div>
               )}
 
@@ -20312,7 +20312,8 @@ Return ONLY raw JSON:
               </div>
               <div style={{fontSize:13,color:"var(--ink-2)",lineHeight:1.5}}>
                 {!sbUser
-                  ? "Create a free account — 3 full runs, zero credit card. Full ICP, deep briefs, RIVER hypothesis, and the confidence that comes from actually doing your homework."
+                  ? "Create a free account — 10 full runs, zero credit card. Full ICP, deep briefs, RIVER hypothesis, and the confidence that comes from actually doing your homework."
+                  : orgCtx?.plan==="trial" && promoOffer==="monthly" && (orgCtx?.run_count||0) >= (orgCtx?.run_limit||0) ? `You've used all ${orgCtx?.run_limit||10} free runs. Unlock 20 more for half off — $45/mo for 2 months, then Starter.`
                   : orgCtx?.plan==="trial" ? `You've used ${orgCtx?.run_count||0} of ${orgCtx?.run_limit||3} trial runs. If the briefs made you better, imagine what a full month does.`
                   : `You're on the ${orgCtx?.plan} plan (${orgCtx?.run_count||0}/${orgCtx?.run_limit||3} runs used). Need more firepower?`}
               </div>
@@ -20359,7 +20360,7 @@ Return ONLY raw JSON:
                     <span style={{fontSize:12,color:"var(--ink-3)"}}>/mo</span>
                   </div>
                   <div style={{fontSize:11,color:"var(--tan-0)",fontWeight:600,marginBottom:2}}>20 runs / month</div>
-                  <div style={{fontSize:11,color:"var(--ink-3)",marginBottom:10}}>Exclusive {orgCtx.promo_code} offer — 2 months, then Starter at $99/mo</div>
+                  <div style={{fontSize:11,color:"var(--ink-3)",marginBottom:10}}>Half off Starter — 2 months at $45, then $99/mo</div>
                   {["Full ICP + brief pipeline","RIVER hypothesis + discovery","Milton coaching","Paid-tier knowledge layers"].map(f=>(
                     <div key={f} style={{fontSize:11,color:"var(--ink-1)",padding:"2px 0",display:"flex",gap:6}}>
                       <span style={{color:"var(--green)",flexShrink:0}}>✓</span>{f}

--- a/src/components/SuperAdmin.jsx
+++ b/src/components/SuperAdmin.jsx
@@ -29,7 +29,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
   const [error, setError] = useState("");
   const [tab, setTab] = useState("overview"); // overview | users | activity | urls
   const [plans, setPlans] = useState([
-    { id: "trial", name: "Trial", tokens: 3, maxTokens: 0, price: 0, costPerToken: 1.16 },
+    { id: "trial", name: "Trial", tokens: 10, maxTokens: 0, price: 0, costPerToken: 1.16 },
     { id: "starter", name: "Starter", tokens: 25, maxTokens: 5, price: 99, costPerToken: 1.16 },
     { id: "pro", name: "Pro", tokens: 100, maxTokens: 20, price: 349, costPerToken: 1.16 },
     { id: "team", name: "Team", tokens: 250, maxTokens: 50, price: 799, costPerToken: 1.16 },
@@ -1297,7 +1297,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                     if (!name) { setPlanSaveMsg("Org name required"); setTimeout(() => setPlanSaveMsg(""), 3000); return; }
                     const url = document.getElementById("sa-new-org-url")?.value?.trim();
                     const plan = document.getElementById("sa-new-org-plan")?.value || "trial";
-                    const limits = { trial: { run_limit: 3, max_run_limit: 0 }, starter: { run_limit: 25, max_run_limit: 5 }, pro: { run_limit: 100, max_run_limit: 20 }, team: { run_limit: 250, max_run_limit: 50 }, enterprise: { run_limit: 1000, max_run_limit: 200 } };
+                    const limits = { trial: { run_limit: 10, max_run_limit: 0 }, starter: { run_limit: 25, max_run_limit: 5 }, pro: { run_limit: 100, max_run_limit: 20 }, team: { run_limit: 250, max_run_limit: 50 }, enterprise: { run_limit: 1000, max_run_limit: 200 } };
                     const body = { name, plan, ...(limits[plan] || {}) };
                     if (url) body.seller_url = url.startsWith("http") ? url : `https://${url}`;
                     try {
@@ -1369,7 +1369,7 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
                                   return (
                                 <select defaultValue={o.plan} onChange={e => {
                                   const plan = e.target.value;
-                                  const limits = { trial: { run_limit: 3, max_run_limit: 0 }, starter: { run_limit: 25, max_run_limit: 5, rollover_cap: 25 }, pro: { run_limit: 100, max_run_limit: 20, rollover_cap: 100 }, team: { run_limit: 250, max_run_limit: 50, rollover_cap: 250 }, enterprise: { run_limit: 1000, max_run_limit: 200, rollover_cap: 1000 }, promo_monthly: { run_limit: 20, max_run_limit: 0, rollover_cap: 20 } };
+                                  const limits = { trial: { run_limit: 10, max_run_limit: 0 }, starter: { run_limit: 25, max_run_limit: 5, rollover_cap: 25 }, pro: { run_limit: 100, max_run_limit: 20, rollover_cap: 100 }, team: { run_limit: 250, max_run_limit: 50, rollover_cap: 250 }, enterprise: { run_limit: 1000, max_run_limit: 200, rollover_cap: 1000 }, promo_monthly: { run_limit: 20, max_run_limit: 0, rollover_cap: 20 } };
                                   patchOrg({ plan, ...(limits[plan] || {}) }, `${o.name} \u2192 ${plan}${limits[plan]?.run_limit ? ` (${limits[plan].run_limit} runs)` : ""}`);
                                 }} style={{ background: ps.bg, borderColor: ps.border, color: ps.border, fontWeight: 700 }}>
                                   <option value="trial">Trial</option>

--- a/supabase/migrations/038_promo_funnel_all_trials.sql
+++ b/supabase/migrations/038_promo_funnel_all_trials.sql
@@ -1,0 +1,27 @@
+-- Migration 038: promo funnel for all trials (issue #151)
+--
+-- The 10-free-runs → $45/mo half-off → Starter funnel becomes the default
+-- new-user path, promo code or not:
+--   1. New orgs start with 10 free runs (was 3, migration 010).
+--   2. promo_offer_kind() no longer requires an admitting promo code for the
+--      'monthly' offer — any trial org qualifies. Run-pack codes still map
+--      to 'run_pack'.
+-- Existing org rows are untouched. Run order: after 037. Safe to re-run.
+
+ALTER TABLE public.orgs ALTER COLUMN run_limit SET DEFAULT 10;
+
+CREATE OR REPLACE FUNCTION public.promo_offer_kind()
+RETURNS text AS $$
+  SELECT CASE
+    WHEN pc.grants_run_pack AND o.plan IN ('trial', 'promo') THEN 'run_pack'
+    WHEN o.plan = 'trial' THEN 'monthly'
+    ELSE NULL
+  END
+  FROM public.users u
+  JOIN public.orgs o ON o.id = u.org_id
+  LEFT JOIN public.promo_codes pc ON pc.code = o.promo_code AND pc.active
+  WHERE u.id = auth.uid()::text
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+REVOKE ALL ON FUNCTION public.promo_offer_kind() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.promo_offer_kind() TO authenticated;


### PR DESCRIPTION
Production flip. Rollback tag: `main-pre-promo-all-trials`.

Ships #151 only: the 10-free-runs → $45/mo half-off → Starter funnel becomes the default new-user path — every new trial gets 10 free runs, the $45 offer no longer requires a promo code, the limit-hit modal pitches the half-off offer, and the monthly cron stops refreshing trial run counts (free runs are one-time).

Post-merge step: apply migration 038 to the prod database AFTER this deploys (RPC change must not precede the checkout change).