### PR TITLE
release: referral program fixes (#154)

### DIFF
--- a/api/_admin-action.js
+++ b/api/_admin-action.js
@@ -250,8 +250,10 @@ export default async function handler(req, res) {
       }
 
       // Approve: trial org + invitation + welcome email — same shared path as
-      // promo auto-approve. The claim above is the idempotency gate.
-      const prov = await provisionTrialAccess({ email: row.email, name: row.name, company: row.company, invitedBy: callerEmail });
+      // promo auto-approve. The claim above is the idempotency gate. The
+      // referral code captured at request time (migration 039) rides along so
+      // manually-approved signups still credit the referrer (issue #154).
+      const prov = await provisionTrialAccess({ email: row.email, name: row.name, company: row.company, invitedBy: callerEmail, referredBy: row.referral_code || null });
       if (prov.ok) {
         console.log(`[admin] Approved access request ${requestId} (${row.email}) — org ${prov.orgId}, ${prov.action}`);
         return res.json({ ok: true, message: `Approved ${row.email} — invite ${prov.emailSent ? "sent" : "NOT sent (check logs)"}` });

--- a/api/_provision.js
+++ b/api/_provision.js
@@ -91,7 +91,7 @@ async function sendInviteEmail(email, invitationToken) {
  * Returns { ok: true, orgId, invitationId, emailSent, action }
  *      or { ok: false, reason } — caller should fall back to the manual queue.
  */
-export async function provisionTrialAccess({ email, name, company, invitedBy = "system", promoCode = null }) {
+export async function provisionTrialAccess({ email, name, company, invitedBy = "system", promoCode = null, referredBy = null }) {
   if (!SB_URL || !SB_KEY) return { ok: false, reason: "not_configured" };
   const cleanEmail = email.trim().toLowerCase();
 
@@ -123,11 +123,15 @@ export async function provisionTrialAccess({ email, name, company, invitedBy = "
     return { ok: false, reason: "org_create_failed" };
   }
 
+  // referred_by (migration 039) is copied onto the users row by the
+  // auto_provision trigger at signup — server-side referral attribution
+  // that survives the email hop (issue #154).
   const invResult = await sbFetch("invitations", "POST", {
     org_id: orgId,
     email: cleanEmail,
     role: "admin",
     invited_by: invitedBy,
+    ...(referredBy ? { referred_by: referredBy } : {}),
   });
   const inv = Array.isArray(invResult) ? invResult[0] : invResult;
   if (!inv?.token) {

--- a/api/cron-reset-tokens.js
+++ b/api/cron-reset-tokens.js
@@ -31,6 +31,24 @@ export default async function handler(req, res) {
   }
 
   try {
+    // Step 0: Expire this month's referral bonus runs BEFORE the rollover, so
+    // rollover math sees the base run_limit, not the bonus-inflated one. The
+    // RPC (migration 039) removes referral_bonus_runs from run_limit and zeroes
+    // the counter atomically — bonus runs are a monthly perk, not permanent
+    // capacity (issue #154).
+    let referralExpired = 0;
+    try {
+      const expRes = await fetch(`${SB_URL}/rest/v1/rpc/expire_referral_bonus`, {
+        method: "POST",
+        headers: { apikey: SB_KEY, Authorization: `Bearer ${SB_KEY}`, "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      const expData = await expRes.json();
+      referralExpired = expData?.orgs_processed || 0;
+    } catch (e) {
+      console.warn("[cron] expire_referral_bonus failed:", e.message);
+    }
+
     // Step 1: Process rollover for paid orgs (atomic RPC)
     const rolloverRes = await fetch(`${SB_URL}/rest/v1/rpc/process_monthly_rollover`, {
       method: "POST",
@@ -66,17 +84,9 @@ export default async function handler(req, res) {
     // same as the old one-time run pack.
     const trialCount = 0;
 
-    // Step 3: Reset referral bonus counters (monthly cap resets)
-    await fetch(`${SB_URL}/rest/v1/orgs?referral_bonus_runs=gt.0`, {
-      method: "PATCH",
-      headers: {
-        apikey: SB_KEY,
-        Authorization: `Bearer ${SB_KEY}`,
-        "Content-Type": "application/json",
-        Prefer: "return=minimal",
-      },
-      body: JSON.stringify({ referral_bonus_runs: 0 }),
-    });
+    // Step 3 (referral bonus reset) now happens in Step 0 via
+    // expire_referral_bonus() — the counter AND the bonus capacity expire
+    // together (issue #154).
 
     // Audit log
     await fetch(`${SB_URL}/rest/v1/api_usage_log`, {
@@ -93,12 +103,12 @@ export default async function handler(req, res) {
         input_tokens: 0,
         output_tokens: 0,
         web_searches: 0,
-        endpoint: `paid:${paidCount},trial:${trialCount}`,
+        endpoint: `paid:${paidCount},trial:${trialCount},referral_expired:${referralExpired}`,
       }),
     });
 
-    console.log(`[cron] Monthly cycle: ${paidCount} paid orgs rolled over, ${trialCount} trial orgs reset`);
-    res.status(200).json({ ok: true, paid_rollovers: paidCount, trial_resets: trialCount, timestamp: new Date().toISOString() });
+    console.log(`[cron] Monthly cycle: ${paidCount} paid orgs rolled over, ${trialCount} trial orgs reset, ${referralExpired} referral bonuses expired`);
+    res.status(200).json({ ok: true, paid_rollovers: paidCount, trial_resets: trialCount, referral_bonuses_expired: referralExpired, timestamp: new Date().toISOString() });
   } catch (e) {
     console.error("[cron] Monthly cycle failed:", e.message);
     res.status(500).json({ error: "Cycle failed" });

--- a/api/referral.js
+++ b/api/referral.js
@@ -68,7 +68,7 @@ export default async function handler(req, res) {
     return res.json({
       ok: true,
       referral_code: user.referral_code,
-      referral_link: `https://www.cambriancatalyst.ai?ref=${user.referral_code}`,
+      referral_link: `${process.env.VITE_APP_URL || "https://www.cambree.ai"}?ref=${user.referral_code}`,
       total_referred: referralCount,
       total_rewarded: rewardedCount,
       bonus_runs_this_month: bonusRuns,

--- a/api/request-access.js
+++ b/api/request-access.js
@@ -133,7 +133,7 @@ export default async function handler(req, res) {
            || req.headers["x-real-ip"] || req.socket?.remoteAddress || "unknown";
   if (!checkRateLimit(ip)) return res.status(429).json({ error: "Too many requests" });
 
-  const { name, email, company, note, promoCode } = req.body || {};
+  const { name, email, company, note, promoCode, referralCode } = req.body || {};
   if (!name || !email || !company) return res.status(400).json({ error: "Name, email, and company are required" });
   if (!EMAIL_RE.test(email)) return res.status(400).json({ error: "Invalid email format" });
   if (name.length > 200 || email.length > 254 || company.length > 200 || (note && note.length > 2000)) {
@@ -141,6 +141,22 @@ export default async function handler(req, res) {
   }
   const code = typeof promoCode === "string" ? promoCode.trim() : "";
   if (code.length > 64) return res.status(400).json({ error: "Input too long" });
+
+  // Referral attribution (issue #154): validate the ?ref code the visitor
+  // arrived with, but NEVER block a signup on a bad one — an invalid or
+  // unknown code is silently dropped. Valid codes ride the access request →
+  // invitation → users.referred_by (migration 039).
+  let referredBy = null;
+  const rawRef = typeof referralCode === "string" ? referralCode.trim() : "";
+  if (rawRef && /^[a-zA-Z0-9_-]{4,32}$/.test(rawRef)) {
+    try {
+      const refRes = await sbRest(`users?referral_code=eq.${encodeURIComponent(rawRef)}&select=id&limit=1`);
+      if (refRes.ok) {
+        const rows = await refRes.json();
+        if (Array.isArray(rows) && rows.length > 0) referredBy = rawRef;
+      }
+    } catch (e) { console.warn("[request-access] Referral code lookup failed:", e.message); }
+  }
 
   // Normalize: auth + users.email are lowercase, and the dedup/queue matching
   // must treat Louis.Ruiz@ and louis.ruiz@ as the same requester (observed
@@ -178,7 +194,7 @@ export default async function handler(req, res) {
   let requestId = null;
   try {
     const insRes = await sbRest("access_requests", "POST",
-      { name, email: cleanEmail, company, note: note || null, status: "pending", created_at, promo_code: code || null },
+      { name, email: cleanEmail, company, note: note || null, status: "pending", created_at, promo_code: code || null, referral_code: referredBy },
       "return=representation");
     if (insRes.ok) {
       const rows = await insRes.json().catch(() => null);
@@ -189,7 +205,7 @@ export default async function handler(req, res) {
   }
 
   if (codeRedeemed) {
-    const prov = await provisionTrialAccess({ email: cleanEmail, name, company, invitedBy: "system:promo", promoCode: code });
+    const prov = await provisionTrialAccess({ email: cleanEmail, name, company, invitedBy: "system:promo", promoCode: code, referredBy });
     if (prov.ok) {
       if (requestId) {
         try {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4354,7 +4354,7 @@ function PasswordGate({ onAuth }) {
         const r=await apiFetch("/api/request-access",{
           method:"POST",
           headers:{"Content-Type":"application/json"},
-          body:JSON.stringify({name:(first+" "+last).trim(),email,company,...(promoCode.trim()?{promoCode:promoCode.trim()}:{})}),
+          body:JSON.stringify({name:(first+" "+last).trim(),email,company,...(promoCode.trim()?{promoCode:promoCode.trim()}:{}),...(sessionStorage.getItem("pending_referral_code")?{referralCode:sessionStorage.getItem("pending_referral_code")}:{})}),
         });
         if(r.ok){const d=await r.json().catch(()=>({ok:true}));setRequestSent(d);setErr("");}
         else{const d=await r.json().catch(()=>({}));setErr(d.error||"Could not submit your request — please try again.");reqInFlightRef.current=false;}
@@ -5618,6 +5618,7 @@ export default function App(){
   const[intelAdjustments,setIntelAdjustments]=useState({});
   const[intelModalTarget,setIntelModalTarget]=useState(null); // company name for open modal
   const[orgPanelOpen,setOrgPanelOpen]=useState(false); // org settings/team drawer
+  const[orgPanelFocus,setOrgPanelFocus]=useState(null); // 'referral' scrolls the dashboard to Refer & Earn (issue #154)
   const[superAdminOpen,setSuperAdminOpen]=useState(false); // superuser analytics
   // reportPanelOpen removed — consolidated into UserDashboard (orgPanelOpen)
   const[moreMenuOpen,setMoreMenuOpen]=useState(false); // header overflow menu
@@ -14223,6 +14224,11 @@ Return ONLY raw JSON:
                       onMouseEnter={e=>e.currentTarget.style.background="var(--bg-1)"} onMouseLeave={e=>e.currentTarget.style.background="none"}>
                       Plans & Pricing
                     </button>}
+                    {sbUser&&orgCtx&&<button onClick={()=>{loadSessions();setOrgPanelFocus("referral");setOrgPanelOpen(true);setMoreMenuOpen(false);}}
+                      style={{width:"100%",padding:"8px 16px",border:"none",background:"none",cursor:"pointer",fontSize:12,fontWeight:600,color:"var(--ink-1)",display:"flex",alignItems:"center",gap:10,textAlign:"left"}}
+                      onMouseEnter={e=>e.currentTarget.style.background="var(--bg-1)"} onMouseLeave={e=>e.currentTarget.style.background="none"}>
+                      Refer & Earn
+                    </button>}
 
                     {/* SUPPORT */}
                     <div style={{height:1,background:"var(--line-0)",margin:"4px 0"}}/>
@@ -20085,7 +20091,7 @@ Return ONLY raw JSON:
 
       {/* User dashboard (replaces OrgPanel + ReportPanel) */}
       {orgPanelOpen && (
-        <UserDashboard orgCtx={orgCtx} setOrgCtx={setOrgCtx} sbUser={sbUser} sbToken={sbToken} savedSessions={savedSessions} onClose={()=>setOrgPanelOpen(false)} onHubspotChange={setHubspotStatus} />
+        <UserDashboard orgCtx={orgCtx} setOrgCtx={setOrgCtx} sbUser={sbUser} sbToken={sbToken} savedSessions={savedSessions} initialFocus={orgPanelFocus} onClose={()=>{setOrgPanelOpen(false);setOrgPanelFocus(null);}} onHubspotChange={setHubspotStatus} />
       )}
 
       {/* Reporting panel */}

--- a/src/components/SuperAdmin.jsx
+++ b/src/components/SuperAdmin.jsx
@@ -2399,12 +2399,6 @@ export default function SuperAdmin({ sbUser, sbToken, orgCtx, onClose }) {
             setOpenMenu(null);
           }}>Clone Setup to User</button>
           <button className="admin-action-item" onClick={() => {
-            navigator.clipboard?.writeText(`${window.location.origin}?ref=admin`);
-            setPlanSaveMsg("Signup link copied");
-            setTimeout(() => setPlanSaveMsg(""), 3000);
-            setOpenMenu(null);
-          }}>Copy Invite Link</button>
-          <button className="admin-action-item" onClick={() => {
             apiFetch("/api/invite", { method: "POST", headers: { "Content-Type": "application/json", Authorization: `Bearer ${sbToken}` },
               body: JSON.stringify({ email: menuContext.email, role: menuContext.role }) })
               .then(r => r.json()).then(d => setPlanSaveMsg(d.ok ? (d.note || `Sent to ${menuContext.email}`) : `Error: ${d.error}`))

--- a/src/components/UserDashboard.jsx
+++ b/src/components/UserDashboard.jsx
@@ -126,7 +126,18 @@ const r = (role) => ROLE_META[role] || ROLE_META.rep;
 // Lazy import OrgPanel for no-org users
 import OrgPanel from "./OrgPanel.jsx";
 
-export default function UserDashboard({ orgCtx, setOrgCtx, sbUser, sbToken, savedSessions, onClose, onHubspotChange }) {
+export default function UserDashboard({ orgCtx, setOrgCtx, sbUser, sbToken, savedSessions, initialFocus, onClose, onHubspotChange }) {
+  // Deep-link from the account menu's "Refer & Earn" item (issue #154): the
+  // widget sits at the bottom of the dashboard tab, so scroll it into view.
+  // Declared before the no-org early return so hook order stays stable.
+  const referralRef = React.useRef(null);
+  React.useEffect(() => {
+    if (initialFocus === "referral") {
+      const t = setTimeout(() => referralRef.current?.scrollIntoView({ behavior: "smooth", block: "center" }), 150);
+      return () => clearTimeout(t);
+    }
+  }, [initialFocus]);
+
   // If user has no org, show the simplified OrgPanel (has "Create Organization" flow)
   if (!orgCtx) return <OrgPanel orgCtx={orgCtx} setOrgCtx={setOrgCtx} sbUser={sbUser} sbToken={sbToken} onClose={onClose} />;
 
@@ -627,7 +638,7 @@ export default function UserDashboard({ orgCtx, setOrgCtx, sbUser, sbToken, save
               </div>
 
               {/* Referral widget */}
-              <div style={{ background: "var(--bg-1)", borderRadius: 10, padding: "14px 18px" }}>
+              <div ref={referralRef} style={{ background: "var(--bg-1)", borderRadius: 10, padding: "14px 18px" }}>
                 <div style={{ fontSize: 11, fontWeight: 700, color: "var(--tan-0)", textTransform: "uppercase", letterSpacing: "0.4px", marginBottom: 8 }}>Refer & Earn</div>
                 <div style={{ fontSize: 12, color: "var(--ink-2)", lineHeight: 1.6, marginBottom: 8 }}>
                   Share your referral link. When someone signs up and runs their first brief, your org gets <strong>+1 bonus run</strong> (up to 5/month).

--- a/supabase/migrations/039_referral_attribution.sql
+++ b/supabase/migrations/039_referral_attribution.sql
@@ -1,0 +1,96 @@
+-- Migration 039: server-side referral attribution + monthly bonus expiry (issue #154)
+--
+-- The referral program never attributed a signup in production: the ?ref code
+-- lived in the visitor's sessionStorage and the invite-gated funnel crosses an
+-- email hop into a fresh tab, stranding it. Attribution now rides the funnel
+-- server-side, same pattern as promo codes:
+--   request-access form → access_requests.referral_code (audit)
+--                       → invitations.referred_by (provisioning)
+--                       → users.referred_by (auto-provision trigger, below)
+--
+-- Also: referral rewards were permanent capacity — increment_referral_bonus
+-- (migration 019) raises run_limit and the monthly cron only zeroed the earn
+-- counter, so every referral was +1 run forever (and, post-#151, a way for
+-- trial orgs to farm free runs indefinitely). expire_referral_bonus() makes
+-- the bonus a monthly perk: the cron now removes expiring bonus runs from
+-- run_limit when it resets the counter.
+--
+-- Run order: after 038. Additive; safe to re-run. Existing rows untouched.
+
+ALTER TABLE public.invitations ADD COLUMN IF NOT EXISTS referred_by text;
+ALTER TABLE public.access_requests ADD COLUMN IF NOT EXISTS referral_code text;
+
+-- Same trigger as migration 004/018, plus: carry the invitation's referred_by
+-- onto the new user row (never overwriting a value that is somehow already set).
+CREATE OR REPLACE FUNCTION public.auto_provision_trial_org()
+RETURNS trigger AS $$
+DECLARE
+  v_inv RECORD;
+BEGIN
+  -- If org_id already set (e.g., by a different process), do nothing
+  IF NEW.org_id IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Check for a pending invitation matching this email
+  SELECT id, org_id, role, referred_by INTO v_inv
+  FROM public.invitations
+  WHERE email = lower(trim(NEW.email))
+    AND accepted_at IS NULL
+    AND expires_at > now()
+  ORDER BY created_at DESC
+  LIMIT 1;
+
+  IF v_inv.id IS NOT NULL THEN
+    -- Invitation found — join that org directly
+    NEW.org_id := v_inv.org_id;
+    NEW.role := COALESCE(v_inv.role, 'rep');
+    IF NEW.referred_by IS NULL THEN
+      NEW.referred_by := v_inv.referred_by;
+    END IF;
+
+    -- Mark the invitation as accepted so it can't be reused
+    UPDATE public.invitations
+    SET accepted_at = now()
+    WHERE id = v_inv.id;
+
+    RETURN NEW;
+  END IF;
+
+  -- No invitation found — leave org_id NULL
+  -- User can create an org or get invited later
+  NEW.role := 'rep';
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Monthly expiry: remove this month's bonus runs from run_limit and zero the
+-- earn counter, atomically per org. Called by cron-reset-tokens.js (service
+-- role) in place of the old counter-only PATCH. GREATEST guards against a
+-- run_limit that was manually lowered below the outstanding bonus.
+CREATE OR REPLACE FUNCTION public.expire_referral_bonus()
+RETURNS jsonb AS $$
+DECLARE
+  v_org record;
+  v_count int := 0;
+BEGIN
+  FOR v_org IN
+    SELECT id, run_limit, referral_bonus_runs
+    FROM public.orgs
+    WHERE referral_bonus_runs > 0
+    FOR UPDATE
+  LOOP
+    UPDATE public.orgs
+    SET run_limit = GREATEST(run_limit - v_org.referral_bonus_runs, 0),
+        referral_bonus_runs = 0,
+        updated_at = now()
+    WHERE id = v_org.id;
+    v_count := v_count + 1;
+  END LOOP;
+
+  RETURN jsonb_build_object('ok', true, 'orgs_processed', v_count);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Service-role only — this rewrites run limits.
+REVOKE ALL ON FUNCTION public.expire_referral_bonus() FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
Production flip. Rollback tag: `main-pre-referral-fixes`.

Ships #154 only — the referral program actually works now (verified end-to-end on staging: attribution → invitation → user row → first-brief +1 reward):
- Referral codes ride the access-request funnel server-side (survives the invite email hop; both promo and manual-approval paths).
- Referral link built from `VITE_APP_URL` instead of the hardcoded old domain.
- Referral bonuses expire monthly via `expire_referral_bonus()` (no permanent run_limit inflation, no trial farming); cron expires before rollover.
- "Refer & Earn" account-menu item deep-links to the referral widget; stray `?ref=admin` admin button removed.

Migration 039 already applied to BOTH prod and staging databases and verified.